### PR TITLE
Basic support for strace

### DIFF
--- a/kernel/calls.c
+++ b/kernel/calls.c
@@ -217,6 +217,7 @@ syscall_t syscall_table[] = {
     [332] = (syscall_t) syscall_stub, // inotify_init1
     [340] = (syscall_t) sys_prlimit64,
     [345] = (syscall_t) sys_sendmmsg,
+    [347] = (syscall_t) syscall_stub, // process_vm_readv
     [352] = (syscall_t) syscall_stub, // sched_getattr
     [353] = (syscall_t) sys_renameat2,
     [355] = (syscall_t) sys_getrandom,
@@ -253,10 +254,29 @@ void handle_interrupt(int interrupt) {
             if (syscall_table[syscall_num] == (syscall_t) syscall_stub) {
                 printk("%d stub syscall %d\n", current->pid, syscall_num);
             }
+            lock(&current->ptrace.lock);
+            if (current->ptrace.stop_at_syscall) {
+                send_signal(current, SIGTRAP_, SIGINFO_NIL);
+                unlock(&current->ptrace.lock);
+                receive_signals();
+                lock(&current->ptrace.lock);
+                current->ptrace.stop_at_syscall = false;
+            }
+            unlock(&current->ptrace.lock);
             STRACE("%d call %-3d ", current->pid, syscall_num);
             int result = syscall_table[syscall_num](cpu->ebx, cpu->ecx, cpu->edx, cpu->esi, cpu->edi, cpu->ebp);
             STRACE(" = 0x%x\n", result);
             cpu->eax = result;
+            lock(&current->ptrace.lock);
+            if (current->ptrace.stop_at_syscall) {
+                current->ptrace.syscall = syscall_num;
+                send_signal(current, SIGTRAP_, SIGINFO_NIL);
+                unlock(&current->ptrace.lock);
+                receive_signals();
+                lock(&current->ptrace.lock);
+                current->ptrace.stop_at_syscall = false;
+            }
+            unlock(&current->ptrace.lock);
         }
     } else if (interrupt == INT_GPF) {
         printk("%d page fault on 0x%x at 0x%x\n", current->pid, cpu->segfault_addr, cpu->eip);

--- a/kernel/ptrace.h
+++ b/kernel/ptrace.h
@@ -16,10 +16,13 @@
 #define PTRACE_SETREGS_ 13
 #define PTRACE_GETFPREGS_ 14
 #define PTRACE_SETFPREGS_ 15
+#define PTRACE_SYSCALL_ 24
 #define PTRACE_SETOPTIONS_ 0x4200
 #define PTRACE_GETSIGINFO_ 0x4202
 
 #define PTRACE_EVENT_FORK_ 1
+
+#define PTRACE_O_TRACESYSGOOD_ 1
 
 struct user_regs_struct_ {
     dword_t ebx;

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -300,7 +300,7 @@ static void receive_signal(struct sighand *sighand, struct siginfo_ *info) {
 void signal_delivery_stop(int sig, struct siginfo_ *info) {
     lock(&current->ptrace.lock);
     current->ptrace.stopped = true;
-    current->ptrace.signal = sig;
+    current->ptrace.signal = sig | current->ptrace.stop_at_syscall << 7;
     current->ptrace.info = *info;
     unlock(&current->ptrace.lock);
     notify(&current->parent->group->child_exit);

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -54,9 +54,13 @@ struct task {
 
         bool traced;
         bool stopped;
+        bool sysgood;
+        bool stop_at_syscall;
+        bool syscall_stopped;
         int signal;
         struct siginfo_ info;
         int trap_event;
+        int syscall;
     } ptrace;
 
     // locked by pids_lock


### PR DESCRIPTION
In particular:

* Stub out process_vm_readv, which is enough for strace to fall back to
using the slower ptrace functions (which we have already implemented)
* Expand PTRACE_SETOPTIONS to (sloppily) support PTRACE_O_TRACESYSGOOD
* Add an implementation of PTRACE_SYSCALL