### PR TITLE
Handle AT_EMPTY_PATH for fstatat64

### DIFF
--- a/fs/mount.c
+++ b/fs/mount.c
@@ -155,7 +155,7 @@ dword_t sys_mount(addr_t source_addr, addr_t point_addr, addr_t type_addr, dword
         return _EINVAL;
 
     struct statbuf stat;
-    int err = generic_statat(AT_PWD, point_raw, &stat, true);
+    int err = generic_statat(AT_PWD, point_raw, &stat, 0);
     if (err < 0)
         return err;
     if (!S_ISDIR(stat.mode))

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -561,7 +561,7 @@ dword_t sys_getcwd(addr_t buf_addr, dword_t size) {
 
 static struct fd *open_dir(const char *path) {
     struct statbuf stat;
-    int err = generic_statat(AT_PWD, path, &stat, true);
+    int err = generic_statat(AT_PWD, path, &stat, 0);
     if (err < 0)
         return ERR_PTR(err);
     if (!(stat.mode & S_IFDIR))

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -44,6 +44,7 @@ struct attr {
 #define make_attr(_type, thing) \
     ((struct attr) {.type = attr_##_type, ._type = thing})
 
+#define AT_EMPTY_PATH_ 0x1000
 #define AT_SYMLINK_NOFOLLOW_ 0x100
 
 struct fd *generic_open(const char *path, int flags, int mode);
@@ -61,7 +62,7 @@ int generic_seek(struct fd *fd, off_t_ off, int whence, size_t size);
 #define AC_X 1
 #define AC_F 0
 int generic_accessat(struct fd *dirfd, const char *path, int mode);
-int generic_statat(struct fd *at, const char *path, struct statbuf *stat, bool follow_links);
+int generic_statat(struct fd *at, const char *path, struct statbuf *stat, int flags);
 int generic_setattrat(struct fd *at, const char *path, struct attr attr, bool follow_links);
 int generic_utime(struct fd *at, const char *path, struct timespec atime, struct timespec mtime, bool follow_links);
 ssize_t generic_readlinkat(struct fd *at, const char *path, char *buf, size_t bufsize);


### PR DESCRIPTION
This is used by newer glibc when loading shared objects.

       AT_EMPTY_PATH (since Linux 2.6.39)
              If pathname is an empty string, operate on the file referred to by dirfd (which may have been ob‐
              tained using the open(2) O_PATH flag).  In this case, dirfd can refer to any type  of  file,  not
              just  a  directory,  and  the  behavior  of fstatat() is similar to that of fstat().  If dirfd is
              AT_FDCWD, the call operates on the current working directory.  This flag is  Linux-specific;  de‐
              fine _GNU_SOURCE to obtain its definition.