### PR TITLE
⚡ Bolt: optimize fakefs SQLite synchronous mode

### DIFF
--- a/fs/fake-db.c
+++ b/fs/fake-db.c
@@ -191,6 +191,13 @@ int fake_db_init(struct fakefs_db *fs, const char *db_path, int root_fd) {
     db_check_error(fs);
     sqlite3_finalize(statement);
 
+    // synchronous=NORMAL is safe in WAL mode, and much faster
+    statement = db_prepare(fs, "pragma synchronous=NORMAL");
+    db_check_error(fs);
+    sqlite3_step(statement);
+    db_check_error(fs);
+    sqlite3_finalize(statement);
+
     statement = db_prepare(fs, "pragma foreign_keys=true");
     db_check_error(fs);
     sqlite3_step(statement);


### PR DESCRIPTION
💡 What: Added `PRAGMA synchronous = NORMAL` to `fs/fake-db.c` initialization.
🎯 Why: SQLite defaults to `synchronous = FULL` (or platform equivalent) which causes frequent fsyncs. In WAL mode, `NORMAL` is safe from corruption and much faster.
📊 Impact: Expected significant reduction in write latency for filesystem metadata operations.
🔬 Measurement: Verified with `tests/manual/test_db_pragma.c` which confirmed the mode change from 2 (FULL) to 1 (NORMAL).

---
*PR created automatically by Jules for task [16475962401965604046](https://jules.google.com/task/16475962401965604046) started by @emkey1*