### PR TITLE
🎨 Palette: Add accessibility labels to terminal toolbar buttons

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -104,15 +104,21 @@
     // SF Symbols is cool
     if (@available(iOS 13, *)) {
         [self.infoButton setImage:[UIImage systemImageNamed:@"gear"] forState:UIControlStateNormal];
+        self.infoButton.accessibilityLabel = @"Settings";
         [self.pasteButton setImage:[UIImage systemImageNamed:@"doc.on.clipboard"] forState:UIControlStateNormal];
+        self.pasteButton.accessibilityLabel = @"Paste";
         [self.hideKeyboardButton setImage:[UIImage systemImageNamed:@"keyboard.chevron.compact.down"] forState:UIControlStateNormal];
+        self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
         
         [self.tabKey setTitle:nil forState:UIControlStateNormal];
         [self.tabKey setImage:[UIImage systemImageNamed:@"arrow.right.to.line.alt"] forState:UIControlStateNormal];
+        self.tabKey.accessibilityLabel = @"Tab";
         [self.controlKey setTitle:nil forState:UIControlStateNormal];
         [self.controlKey setImage:[UIImage systemImageNamed:@"control"] forState:UIControlStateNormal];
+        self.controlKey.accessibilityLabel = @"Control";
         [self.escapeKey setTitle:nil forState:UIControlStateNormal];
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
+        self.escapeKey.accessibilityLabel = @"Escape";
     }
     
     [UserPreferences.shared observe:@[@"hideStatusBar"] options:0 owner:self usingBlock:^(typeof(self) self) {


### PR DESCRIPTION
💡 What: Added `accessibilityLabel` to several toolbar buttons in `TerminalViewController.m` when using SF Symbols (iOS 13+).
🎯 Why: These buttons become icon-only when SF Symbols are used, making them inaccessible to screen readers without explicit labels.
♿ Accessibility: VoiceOver will now announce "Settings", "Paste", "Hide Keyboard", "Tab", "Control", and "Escape" for the respective buttons.

---
*PR created automatically by Jules for task [74858981463573482](https://jules.google.com/task/74858981463573482) started by @emkey1*