### PR TITLE
🧹 Remove dead code in fs/tmp.c

### DIFF
--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -224,21 +224,6 @@ static int tmpfs_mount(struct mount *mount) {
     return 0;
 }
 
-#if 0
-// This is the only place where a tmpfs directory tree is recursively freed.
-static void tmpfs_unmount_tree(struct tmp_inode *tree) {
-    assert(refcount_get(tree) == 1); // otherwise mount_remove should have returned EBUSY
-    if (S_ISDIR(tree->stat.mode)) {
-        struct tmp_dirent *dirent, *tmp;
-        list_for_each_entry_safe(&tree->dir.entries, dirent, tmp, dir) {
-            if (dirent->inode != NULL)
-                tmpfs_unmount_tree(dirent->inode);
-            tmp_dirent_release(dirent);
-        }
-    }
-    tmp_inode_release(tree);
-}
-#endif
 
 static int tmpfs_umount(struct mount *UNUSED(mount)) {
     // big fat fuckin TODO


### PR DESCRIPTION
Removed the `#if 0` block in `fs/tmp.c` containing `tmpfs_unmount_tree`. This function was dead code and implemented using incorrect data structures (treating `tmp_inode` as directory container instead of `tmp_dirent`). `tmpfs_umount` remains a TODO as per current codebase state. verified compilation and removal of build artifacts.

---
*PR created automatically by Jules for task [16340702484707475085](https://jules.google.com/task/16340702484707475085) started by @emkey1*