### PR TITLE
🔒 Fix stack buffer overflow in fs/proc/ish.c

### DIFF
--- a/fs/proc/ish.c
+++ b/fs/proc/ish.c
@@ -2,6 +2,7 @@
 #include "fs/proc/ish.h"
 #include "fs/proc/net.h"
 #include "kernel/errno.h"
+#include "kernel/fs.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -79,7 +80,7 @@ static void proc_ish_defaults_getname(struct proc_entry *entry, char *buf) {
 
 static int proc_ish_defaults_readlink(struct proc_entry *entry, char *buf) {
     char *name = get_underlying_name(entry->name);
-    sprintf(buf, "../.defaults/%s", name);
+    snprintf(buf, MAX_PATH, "../.defaults/%s", name);
     free(name);
     return 0;
 }


### PR DESCRIPTION
Fixed a stack buffer overflow vulnerability in `fs/proc/ish.c` where `sprintf` was used without bounds checking on user input. Replaced with `snprintf` using `MAX_PATH` as the limit.

---
*PR created automatically by Jules for task [5751465263082297567](https://jules.google.com/task/5751465263082297567) started by @emkey1*