### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix error handling bypass in user_read_string

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Unsafe use of `vsprintf` in `ish_vprintk` (16KB static buffer) and `die` (4KB stack buffer) allowed potential buffer overflows if log messages exceeded buffer size. The code explicitly noted "I'm trusting you to not pass an absurdly long message", highlighting known technical debt.
 **Learning:** Even "trusted" internal callers (like `STRACE` via `printk`) can inadvertently trigger overflows with user-controlled input (e.g., long arguments to `execve`).
 **Prevention:** Always use `vsnprintf` to enforce buffer limits. Implement graceful truncation or forced flushing when buffers fill up to prevent data loss or crashes.
+
+## 2026-02-24 - Hidden Error Handling Bypass in Kernel Memory Access
+**Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
+**Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
+**Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".

--- a/kernel/user.c
+++ b/kernel/user.c
@@ -95,7 +95,7 @@ int user_read_string(addr_t addr, char *buf, size_t max) {
     read_lock(&current->mem->lock);
     size_t i = 0;
     while (i < max) {
-        if (__user_read_task(current, addr + i, &buf[i], sizeof(buf[i])), false) {
+        if (__user_read_task(current, addr + i, &buf[i], sizeof(buf[i]))) {
             read_unlock(&current->mem->lock);
             return 1;
         }


### PR DESCRIPTION
Fixed a critical logic error in `user_read_string` where the return value of `__user_read_task` was discarded using the comma operator, causing the function to return success even when reading from invalid memory. This could lead to use of uninitialized memory in path handling.

Verification:
- Created a standalone C test that mocks `mem_ptr` to fail for a specific address.
- Confirmed that the original code returned 0 (success) for the invalid address.
- Confirmed that the fixed code returns 1 (error) for the invalid address.

Also updated Sentinel's Journal with the findings.

---
*PR created automatically by Jules for task [7648062635829104656](https://jules.google.com/task/7648062635829104656) started by @emkey1*