### PR TITLE
🎨 Palette: Improve accessibility for toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Toggle Button Accessibility
+**Learning:** Returning "1" or "0" for `accessibilityValue` on toggle buttons is confusing for screen reader users. Standard practice is to use `UIAccessibilityTraitSelected`.
+**Action:** Replace custom `accessibilityValue` implementations with `UIAccessibilityTraitSelected` for toggleable controls.

--- a/app/BarButton.m
+++ b/app/BarButton.m
@@ -74,18 +74,18 @@ extern UIAccessibilityTraits UIAccessibilityTraitToggle;
 - (void)setSelected:(BOOL)selected {
     [super setSelected:selected];
     [self chooseBackground];
+    if (self.toggleable) {
+        if (selected) {
+            self.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
+    }
 }
 
 - (void)setKeyAppearance:(UIKeyboardAppearance)keyAppearance {
     _keyAppearance = keyAppearance;
     [self chooseBackground];
-}
-
-- (NSString *)accessibilityValue {
-    if (self.toggleable) {
-        return self.selected ? @"1" : @"0";
-    }
-    return nil;
 }
 
 @end


### PR DESCRIPTION
💡 What: Replaced custom accessibility value ("1"/"0") with standard `UIAccessibilityTraitSelected` for toggle buttons.
🎯 Why: Returning "1" or "0" is confusing for screen reader users. The standard "Selected" trait provides a better, localized experience.
♿ Accessibility: VoiceOver will now announce "Selected" when toggle buttons (like Control) are active.


---
*PR created automatically by Jules for task [5156947750018650176](https://jules.google.com/task/5156947750018650176) started by @emkey1*