### PR TITLE
⚡ Bolt: Optimize fakefs readdir with batched transactions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - [FakeFS Readdir Optimization]
+**Learning:** `fakefs` directory listings were performing a SQLite transaction for *every single entry*, causing massive overhead. The filesystem abstraction lacked hooks to batch these operations.
+**Action:** Implemented `readdir_begin` and `readdir_end` hooks in `fd_ops` and updated `fakefs` to use a single transaction for the entire directory listing. Also switched to recursive mutexes to safely handle nested transaction requests.

--- a/fs/dir.c
+++ b/fs/dir.c
@@ -68,6 +68,9 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
 
     dword_t orig_count = count;
 
+    if (fd->ops->readdir_begin)
+        fd->ops->readdir_begin(fd);
+
     long ptr;
     int err;
     int printed = 0;
@@ -78,7 +81,7 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         struct dir_entry entry;
         err = fd->ops->readdir(fd, &entry);
         if (err < 0)
-            return err;
+            goto out;
         if (err == 0)
             break;
 
@@ -98,14 +101,21 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
 
         if (reclen > count)
             break;
-        if (user_write(dirents, dirent_data, reclen))
-            return _EFAULT;
+        if (user_write(dirents, dirent_data, reclen)) {
+            err = _EFAULT;
+            goto out;
+        }
         dirents += reclen;
         count -= reclen;
     }
 
     fd_seekdir(fd, ptr);
-    return orig_count - count;
+    err = orig_count - count;
+
+out:
+    if (fd->ops->readdir_end)
+        fd->ops->readdir_end(fd);
+    return err;
 }
 
 int_t sys_getdents(fd_t f, addr_t dirents, uint_t count) {

--- a/fs/fake-db.c
+++ b/fs/fake-db.c
@@ -42,15 +42,22 @@ void db_exec_reset(struct fakefs_db *fs, sqlite3_stmt *stmt) {
 
 void db_begin(struct fakefs_db *fs) {
     sqlite3_mutex_enter(fs->lock);
-    db_exec_reset(fs, fs->stmt.begin);
+    if (fs->transaction_depth++ == 0)
+        db_exec_reset(fs, fs->stmt.begin);
 }
 void db_commit(struct fakefs_db *fs) {
-    db_exec_reset(fs, fs->stmt.commit);
+    if (--fs->transaction_depth == 0)
+        db_exec_reset(fs, fs->stmt.commit);
     sqlite3_mutex_leave(fs->lock);
 }
 void db_rollback(struct fakefs_db *fs) {
-    db_exec_reset(fs, fs->stmt.rollback);
-    sqlite3_mutex_leave(fs->lock);
+    if (fs->transaction_depth > 0) {
+        db_exec_reset(fs, fs->stmt.rollback);
+        while (fs->transaction_depth > 0) {
+            fs->transaction_depth--;
+            sqlite3_mutex_leave(fs->lock);
+        }
+    }
 }
 
 static void bind_path(sqlite3_stmt *stmt, int i, const char *path) {
@@ -248,7 +255,8 @@ int fake_db_init(struct fakefs_db *fs, const char *db_path, int root_fd) {
     db_check_error(fs);
     sqlite3_finalize(statement);
 
-    fs->lock = sqlite3_mutex_alloc(SQLITE_MUTEX_FAST);
+    fs->transaction_depth = 0;
+    fs->lock = sqlite3_mutex_alloc(SQLITE_MUTEX_RECURSIVE);
     fs->stmt.begin = db_prepare(fs, "begin");
     fs->stmt.commit = db_prepare(fs, "commit");
     fs->stmt.rollback = db_prepare(fs, "rollback");

--- a/fs/fake-db.h
+++ b/fs/fake-db.h
@@ -24,6 +24,7 @@ struct fakefs_db {
         sqlite3_stmt *try_cleanup_inode;
     } stmt;
     sqlite3_mutex *lock;
+    int transaction_depth;
 };
 
 int fake_db_init(struct fakefs_db *fs, const char *db_path, int root_fd);

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -317,6 +317,15 @@ static ssize_t fakefs_readlink(struct mount *mount, const char *path, char *buf,
     return err;
 }
 
+static void fakefs_readdir_begin(struct fd *fd) {
+    struct fakefs_db *fs = &fd->mount->fakefs;
+    db_begin(fs);
+}
+static void fakefs_readdir_end(struct fd *fd) {
+    struct fakefs_db *fs = &fd->mount->fakefs;
+    db_commit(fs);
+}
+
 static int fakefs_readdir(struct fd *fd, struct dir_entry *entry) {
     assert(fd->ops == &fakefs_fdops);
     int res;
@@ -353,6 +362,8 @@ static struct fd_ops fakefs_fdops;
 static void __attribute__((constructor)) init_fake_fdops() {
     fakefs_fdops = realfs_fdops;
     fakefs_fdops.readdir = fakefs_readdir;
+    fakefs_fdops.readdir_begin = fakefs_readdir_begin;
+    fakefs_fdops.readdir_end = fakefs_readdir_end;
 }
 
 static int fakefs_mount(struct mount *mount) {

--- a/fs/fd.h
+++ b/fs/fd.h
@@ -141,6 +141,10 @@ struct fd_ops {
     // Reads a directory entry from the stream
     // required for directories
     int (*readdir)(struct fd *fd, struct dir_entry *entry);
+    // Called before a sequence of readdir calls
+    void (*readdir_begin)(struct fd *fd);
+    // Called after a sequence of readdir calls
+    void (*readdir_end)(struct fd *fd);
     // Return an opaque value representing the current point in the directory stream
     // optional, fd->offset will be used instead
     unsigned long (*telldir)(struct fd *fd);


### PR DESCRIPTION
⚡ Bolt: Optimize fakefs readdir with batched transactions

💡 **What:**
- Added `readdir_begin` and `readdir_end` hooks to `struct fd_ops`.
- Updated `sys_getdents_common` to call these hooks.
- Implemented these hooks in `fakefs` to wrap the directory listing loop in a single database transaction.
- Updated `fakefs` database helpers (`db_begin`, `db_commit`, `db_rollback`) to support nested transactions.
- Changed `fakefs` mutex to `SQLITE_MUTEX_RECURSIVE` to support the nested locking required by this change.

🎯 **Why:**
Previously, `fakefs` initiated a new SQLite transaction for *every single file* returned by `readdir`. This caused massive overhead for directory listings (`ls`), making them extremely slow. By batching these into a single transaction, we amortize the transaction cost over the entire directory listing.

📊 **Impact:**
- Drastic reduction in database transaction overhead for directory listings.
- `ls` and other directory traversal operations on `fakefs` should be significantly faster.

🔬 **Measurement:**
- Verify that `ls -R` or `find .` on a large directory tree in `fakefs` is faster.
- Check SQLite logs (if enabled) to see fewer BEGIN/COMMIT pairs during directory listings.

---
*PR created automatically by Jules for task [8726341816130165481](https://jules.google.com/task/8726341816130165481) started by @emkey1*