### PR TITLE
🎨 Palette: Improved accessibility for toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility for Toggle Buttons
+**Learning:** Avoid using custom "1"/"0" strings in `accessibilityValue` for toggle states.
+**Action:** Use `UIAccessibilityTraitSelected` dynamically in `setSelected:`. This provides standard, localized voice feedback (e.g., "Selected") automatically.

--- a/app/BarButton.m
+++ b/app/BarButton.m
@@ -10,8 +10,6 @@
 @interface BarButton ()
 @end
 
-extern UIAccessibilityTraits UIAccessibilityTraitToggle;
-
 @implementation BarButton
 
 - (void)awakeFromNib {
@@ -23,8 +21,8 @@ extern UIAccessibilityTraits UIAccessibilityTraitToggle;
     self.backgroundColor = self.defaultColor;
     self.keyAppearance = UIKeyboardAppearanceLight;
     self.accessibilityTraits |= UIAccessibilityTraitKeyboardKey;
-    if (self.toggleable) {
-        self.accessibilityTraits |= 0x20000000000000;
+    if (self.toggleable && self.selected) {
+        self.accessibilityTraits |= UIAccessibilityTraitSelected;
     }
 }
 
@@ -74,18 +72,18 @@ extern UIAccessibilityTraits UIAccessibilityTraitToggle;
 - (void)setSelected:(BOOL)selected {
     [super setSelected:selected];
     [self chooseBackground];
+    if (self.toggleable) {
+        if (selected) {
+            self.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
+    }
 }
 
 - (void)setKeyAppearance:(UIKeyboardAppearance)keyAppearance {
     _keyAppearance = keyAppearance;
     [self chooseBackground];
-}
-
-- (NSString *)accessibilityValue {
-    if (self.toggleable) {
-        return self.selected ? @"1" : @"0";
-    }
-    return nil;
 }
 
 @end


### PR DESCRIPTION
Replaced legacy toggle implementation in `BarButton` with standard `UIAccessibilityTraitSelected`. This ensures VoiceOver users hear "Selected" instead of confusing "1" or "0" values, and removes usage of a magic number trait.

Changes:
- Removed `extern UIAccessibilityTraitToggle`.
- Replaced magic number `0x20000000000000` with `UIAccessibilityTraitSelected` logic.
- Updated `setSelected:` to dynamically toggle the trait.
- Removed `accessibilityValue` override.

---
*PR created automatically by Jules for task [10528121732752118880](https://jules.google.com/task/10528121732752118880) started by @emkey1*