### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack buffer overflow in path resolution

### DIFF
--- a/fs/path.c
+++ b/fs/path.c
@@ -87,6 +87,8 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
                 char *expanded_path = possible_symlink;
                 strcpy(expanded_path, out);
                 if (strcmp(p, "") != 0) {
+                    if (strlen(expanded_path) + 1 + strlen(p) >= MAX_PATH)
+                        return _ENAMETOOLONG;
                     strcat(expanded_path, "/");
                     strcat(expanded_path, p);
                 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Stack buffer overflow in `fs/path.c`. When resolving a symlink, the code appended the remaining path component `p` to the resolved symlink path `expanded_path` using `strcat` without checking if the total length exceeds `MAX_PATH` (4096 bytes). A crafted path (e.g., a symlink to a long path + a long suffix) could overflow the `possible_symlink` stack buffer.
🎯 Impact: This could lead to memory corruption, potential code execution, or denial of service (crash) when processing malicious paths.
🔧 Fix: Added a length check before `strcat`. If `strlen(expanded_path) + 1 + strlen(p) >= MAX_PATH`, the function now returns `_ENAMETOOLONG`.
✅ Verification: Created a reproduction script `reproduce_overflow.c` that simulated the vulnerable condition and confirmed that the unpatched code crashed (stack smashing), while the patched code correctly returned `_ENAMETOOLONG`. Also verified syntax with `gcc -fsyntax-only`.

---
*PR created automatically by Jules for task [2243233394131304678](https://jules.google.com/task/2243233394131304678) started by @emkey1*