### PR TITLE
⚡ Bolt: Cache mount point length for faster path resolution

### DIFF
--- a/fs/generic.c
+++ b/fs/generic.c
@@ -13,7 +13,7 @@
 struct mount *find_mount_and_trim_path(char *path) {
     struct mount *mount = mount_find(path);
     char *dst = path;
-    const char *src = path + strlen(mount->point);
+    const char *src = path + mount->point_len;
     while (*src != '\0')
         *dst++ = *src++;
     *dst = '\0';
@@ -108,10 +108,12 @@ int generic_getpath(struct fd *fd, char *buf) {
         int err = fd->mount->fs->getpath(fd, buf);
         if (err < 0)
             return err;
-        if (strlen(buf) + strlen(fd->mount->point) >= MAX_PATH)
+        size_t point_len = fd->mount->point_len;
+        size_t buf_len = strlen(buf);
+        if (buf_len + point_len >= MAX_PATH)
             return _ENAMETOOLONG;
-        memmove(buf + strlen(fd->mount->point), buf, strlen(buf) + 1);
-        memcpy(buf, fd->mount->point, strlen(fd->mount->point));
+        memmove(buf + point_len, buf, buf_len + 1);
+        memcpy(buf, fd->mount->point, point_len);
         if (buf[0] == '\0')
             memcpy(buf, "/", 2);
         return 0;

--- a/fs/mount.c
+++ b/fs/mount.c
@@ -70,6 +70,7 @@ int do_mount(const struct fs_ops *fs, const char *source, const char *point, con
     if (new_mount == NULL)
         return _ENOMEM;
     new_mount->point = strdup(point);
+    new_mount->point_len = strlen(point);
     new_mount->source = strdup(source);
     new_mount->info = strdup(info);
     new_mount->flags = flags;

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -72,6 +72,7 @@ int access_check(struct statbuf *stat, int check);
 
 struct mount {
     const char *point;
+    size_t point_len;
     const char *source;
     const char *info;
     int flags;


### PR DESCRIPTION
💡 What: Added `point_len` to `struct mount` and used it in place of `strlen(mount->point)` in `fs/mount.c` and `fs/generic.c`.
🎯 Why: `strlen` is O(N) and was being called repeatedly (multiple times per path component lookup) in critical file system operations.
📊 Impact: Reduces overhead of path resolution. Although micro-optimization, it affects every file access.
🔬 Measurement: Verified logic correctness with a standalone test `tests/manual/test_mount_opt.c` (which passed) and syntax correctness with `gcc -fsyntax-only`. Benchmark showed that manual loop optimization for path normalization was slower, so focused on this architectural optimization instead.

---
*PR created automatically by Jules for task [13668835387988237915](https://jules.google.com/task/13668835387988237915) started by @emkey1*