### PR TITLE
🎨 Palette: Improve accessibility for toolbar buttons on iOS < 13

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Toggle Button Accessibility
 **Learning:** Returning "1" or "0" for `accessibilityValue` on toggle buttons is confusing for screen reader users. Standard practice is to use `UIAccessibilityTraitSelected`.
 **Action:** Replace custom `accessibilityValue` implementations with `UIAccessibilityTraitSelected` for toggleable controls.
+
+## 2024-05-24 - Accessibility Availability Checks
+**Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
+**Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -104,22 +104,22 @@
     // SF Symbols is cool
     if (@available(iOS 13, *)) {
         [self.infoButton setImage:[UIImage systemImageNamed:@"gear"] forState:UIControlStateNormal];
-        self.infoButton.accessibilityLabel = @"Settings";
         [self.pasteButton setImage:[UIImage systemImageNamed:@"doc.on.clipboard"] forState:UIControlStateNormal];
-        self.pasteButton.accessibilityLabel = @"Paste";
         [self.hideKeyboardButton setImage:[UIImage systemImageNamed:@"keyboard.chevron.compact.down"] forState:UIControlStateNormal];
-        self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
         
         [self.tabKey setTitle:nil forState:UIControlStateNormal];
         [self.tabKey setImage:[UIImage systemImageNamed:@"arrow.right.to.line.alt"] forState:UIControlStateNormal];
-        self.tabKey.accessibilityLabel = @"Tab";
         [self.controlKey setTitle:nil forState:UIControlStateNormal];
         [self.controlKey setImage:[UIImage systemImageNamed:@"control"] forState:UIControlStateNormal];
-        self.controlKey.accessibilityLabel = @"Control";
         [self.escapeKey setTitle:nil forState:UIControlStateNormal];
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
-        self.escapeKey.accessibilityLabel = @"Escape";
     }
+    self.infoButton.accessibilityLabel = @"Settings";
+    self.pasteButton.accessibilityLabel = @"Paste";
+    self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
+    self.tabKey.accessibilityLabel = @"Tab";
+    self.controlKey.accessibilityLabel = @"Control";
+    self.escapeKey.accessibilityLabel = @"Escape";
     
     [UserPreferences.shared observe:@[@"hideStatusBar"] options:0 owner:self usingBlock:^(typeof(self) self) {
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
This PR improves accessibility for the iSH terminal toolbar by ensuring that accessibility labels are applied to buttons regardless of the iOS version. Previously, these labels were only set inside an `@available(iOS 13, *)` block, leaving users on older iOS versions (which iSH supports) with potentially unlabelled buttons if they were not set in the Interface Builder.

Changes:
- Modified `app/TerminalViewController.m` to assign `accessibilityLabel` properties unconditionally.
- Added a journal entry to `.jules/palette.md` documenting the importance of decoupling accessibility logic from version-specific visual logic.

---
*PR created automatically by Jules for task [6446391342205714914](https://jules.google.com/task/6446391342205714914) started by @emkey1*