### PR TITLE
Fix stack buffer overflow in fakefs_readdir

### DIFF
--- a/fs/fake.c
+++ b/fs/fake.c
@@ -343,6 +343,8 @@ retry:
         }
     } else if (strcmp(entry->name, ".") != 0) {
         // god I don't know what to do if this would overflow
+        if (strlen(entry_path) + 1 + strlen(entry->name) >= sizeof(entry_path))
+            goto retry;
         strcat(entry_path, "/");
         strcat(entry_path, entry->name);
     }


### PR DESCRIPTION
Added a bounds check to `fakefs_readdir` in `fs/fake.c` to prevent a stack buffer overflow when concatenating long paths. Verified with a standalone reproduction test case that the overflow is detected and prevented.

---
*PR created automatically by Jules for task [7762809486488317778](https://jules.google.com/task/7762809486488317778) started by @emkey1*