### PR TITLE
🛡️ Sentinel: Fix buffer overflow in path concatenation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-02-24 - Stack Buffer Overflow in Path Manipulation
+**Vulnerability:** Several instances of `strcat` and `strcpy` were used in `fs/fake.c` and `fs/path.c` to append path components to a static buffer (`MAX_PATH` size) without verifying if the length of the concatenated strings would exceed the buffer's capacity. This allows for a stack-based buffer overflow if user-supplied paths are artificially constructed to exceed limits.
+**Learning:** Checking string lengths against `MAX_PATH` is easy to get wrong with an off-by-one error. `strlen(a) + 1 + strlen(b) > MAX_PATH` is flawed because a string of length `MAX_PATH` requires `MAX_PATH + 1` bytes of storage (for the null terminator).
+**Prevention:** When verifying buffer boundaries for string concatenation, always use `>=` against the maximum capacity of the buffer minus one, or ensure the check accounts for the null terminator. Ensure control flow after a failure is safe (e.g. return an error rather than infinitely looping).

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -342,7 +342,8 @@ retry:
             *strrchr(entry_path, '/') = '\0';
         }
     } else if (strcmp(entry->name, ".") != 0) {
-        // god I don't know what to do if this would overflow
+        if (strlen(entry_path) + 1 + strlen(entry->name) >= MAX_PATH)
+            goto retry;
         strcat(entry_path, "/");
         strcat(entry_path, entry->name);
     }

--- a/fs/path.c
+++ b/fs/path.c
@@ -87,6 +87,8 @@ static int __path_normalize(const char *at_path, const char *path, char *out, in
                 char *expanded_path = possible_symlink;
                 strcpy(expanded_path, out);
                 if (strcmp(p, "") != 0) {
+                    if (strlen(expanded_path) + 1 + strlen(p) >= MAX_PATH)
+                        return _ENAMETOOLONG;
                     strcat(expanded_path, "/");
                     strcat(expanded_path, p);
                 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in path concatenation

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded `strcat` and `strcpy` operations in `fs/fake.c` and `fs/path.c` could write past the bounds of a stack-allocated buffer (`entry_path` and `expanded_path`) if a user-supplied path exceeded `MAX_PATH` in length.
🎯 **Impact:** Exploitation of this vulnerability could lead to stack corruption, resulting in memory safety issues, Denial of Service (DoS), or potentially arbitrary code execution within the kernel context.
🔧 **Fix:** Added proper length validation (`strlen(a) + 1 + strlen(b) >= MAX_PATH`) prior to all path concatenation operations. If the resulting path would be too long, the function now gracefully aborts with `_ENAMETOOLONG` or safely skips the directory entry.
✅ **Verification:** Verified that the C code compiles cleanly without syntax errors (`gcc -fsyntax-only`).

---
*PR created automatically by Jules for task [12551095069258872012](https://jules.google.com/task/12551095069258872012) started by @emkey1*