### PR TITLE
🎨 Palette: Fix missing accessibility labels on iOS <13

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Toggle Button Accessibility
 **Learning:** Returning "1" or "0" for `accessibilityValue` on toggle buttons is confusing for screen reader users. Standard practice is to use `UIAccessibilityTraitSelected`.
 **Action:** Replace custom `accessibilityValue` implementations with `UIAccessibilityTraitSelected` for toggleable controls.
+
+## 2024-05-24 - Accessibility labels hidden by OS version checks
+**Learning:** Accessibility labels should not be gated by OS version checks used for visual assets like SF Symbols, as this breaks screen readers on older OS versions.
+**Action:** Always assign `accessibilityLabel` and other a11y properties outside `@available()` checks.

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -101,24 +101,26 @@
         self.barHeight.constant = 43;
     }
     
+    // Ensure accessibility labels are applied regardless of iOS version
+    self.infoButton.accessibilityLabel = @"Settings";
+    self.pasteButton.accessibilityLabel = @"Paste";
+    self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
+    self.tabKey.accessibilityLabel = @"Tab";
+    self.controlKey.accessibilityLabel = @"Control";
+    self.escapeKey.accessibilityLabel = @"Escape";
+
     // SF Symbols is cool
     if (@available(iOS 13, *)) {
         [self.infoButton setImage:[UIImage systemImageNamed:@"gear"] forState:UIControlStateNormal];
-        self.infoButton.accessibilityLabel = @"Settings";
         [self.pasteButton setImage:[UIImage systemImageNamed:@"doc.on.clipboard"] forState:UIControlStateNormal];
-        self.pasteButton.accessibilityLabel = @"Paste";
         [self.hideKeyboardButton setImage:[UIImage systemImageNamed:@"keyboard.chevron.compact.down"] forState:UIControlStateNormal];
-        self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
         
         [self.tabKey setTitle:nil forState:UIControlStateNormal];
         [self.tabKey setImage:[UIImage systemImageNamed:@"arrow.right.to.line.alt"] forState:UIControlStateNormal];
-        self.tabKey.accessibilityLabel = @"Tab";
         [self.controlKey setTitle:nil forState:UIControlStateNormal];
         [self.controlKey setImage:[UIImage systemImageNamed:@"control"] forState:UIControlStateNormal];
-        self.controlKey.accessibilityLabel = @"Control";
         [self.escapeKey setTitle:nil forState:UIControlStateNormal];
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
-        self.escapeKey.accessibilityLabel = @"Escape";
     }
     
     [UserPreferences.shared observe:@[@"hideStatusBar"] options:0 owner:self usingBlock:^(typeof(self) self) {


### PR DESCRIPTION
💡 **What**: Moved the assignments of `accessibilityLabel` for toolbar buttons (`infoButton`, `pasteButton`, `hideKeyboardButton`, `tabKey`, `controlKey`, `escapeKey`) outside of the `if (@available(iOS 13, *))` block in `TerminalViewController.m`. Also added a journal entry to `.jules/palette.md`.

🎯 **Why**: Previously, these accessibility labels were only applied if the user was on iOS 13 or later, because they were grouped with the SF Symbols visual asset assignments. This left VoiceOver users on iOS 12 and below without proper labels for these crucial toolbar buttons. By moving them out, accessibility is preserved regardless of OS version.

♿ **Accessibility**: Fixed missing VoiceOver labels on older iOS versions.

---
*PR created automatically by Jules for task [6431846508464871344](https://jules.google.com/task/6431846508464871344) started by @emkey1*