### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Stack Buffer Overflow in fakefs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-02-25 - Stack Buffer Overflow via Directory Listing
+**Vulnerability:** A missing bounds check in `fakefs_readdir` allowed `entry_path` (a 4096-byte stack buffer) to overflow when encountering directory entries whose path length exceeded `MAX_PATH`. The original code literally commented "god I don't know what to do if this would overflow" instead of handling it.
+**Learning:** String concatenations (`strcat`, `strcpy`) into fixed-size stack buffers must always be verified against the buffer capacity. Unhandled edge cases documented with comments can be straightforward indicators of existing vulnerabilities.
+**Prevention:** Explicitly use bounds checking (`strlen(path) + 1 + strlen(name) >= MAX_PATH`) prior to any concatenation, and safely skip or abort the processing of oversized inputs (e.g. using `goto retry` to skip to the next directory entry).

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -342,7 +342,9 @@ retry:
             *strrchr(entry_path, '/') = '\0';
         }
     } else if (strcmp(entry->name, ".") != 0) {
-        // god I don't know what to do if this would overflow
+        if (strlen(entry_path) + 1 + strlen(entry->name) >= MAX_PATH) {
+            goto retry; // Prevent stack buffer overflow
+        }
         strcat(entry_path, "/");
         strcat(entry_path, entry->name);
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Stack Buffer Overflow in `fs/fake.c`. When constructing the full path for directory entries in `fakefs_readdir`, a missing bounds check before `strcat` could cause `entry_path` (a 4096-byte `char` array allocated on the stack) to overflow if the combined path length exceeds `MAX_PATH`.
🎯 **Impact:** Potential stack buffer overflow leading to kernel crash, denial of service, or arbitrary code execution if a maliciously crafted long path name is processed during directory enumeration.
🔧 **Fix:** Added a strict bounds check: `if (strlen(entry_path) + 1 + strlen(entry->name) >= MAX_PATH)` before concatenation. If the path is too long, the loop safely skips the entry using the existing `goto retry` logic.
✅ **Verification:** Syntax verified with `gcc -fsyntax-only`. The overflow prevention has also been documented in the Sentinel journal.

---
*PR created automatically by Jules for task [16132707877200074945](https://jules.google.com/task/16132707877200074945) started by @emkey1*