### PR TITLE
🎨 Palette: Fix accessibility labels for older iOS versions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Toggle Button Accessibility
 **Learning:** Returning "1" or "0" for `accessibilityValue` on toggle buttons is confusing for screen reader users. Standard practice is to use `UIAccessibilityTraitSelected`.
 **Action:** Replace custom `accessibilityValue` implementations with `UIAccessibilityTraitSelected` for toggleable controls.
+
+## 2024-05-23 - Accessibility Labels and Version Checks
+**Learning:** Accessibility labels must be assigned unconditionally, outside of any version availability checks (e.g., `@available(iOS 13, *)`) used for newer visual assets like SF Symbols. Otherwise, screen reader support is broken for users on older iOS versions.
+**Action:** Always assign `accessibilityLabel` and other accessibility properties outside of version checks.

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -101,24 +101,25 @@
         self.barHeight.constant = 43;
     }
     
+    self.infoButton.accessibilityLabel = @"Settings";
+    self.pasteButton.accessibilityLabel = @"Paste";
+    self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
+    self.tabKey.accessibilityLabel = @"Tab";
+    self.controlKey.accessibilityLabel = @"Control";
+    self.escapeKey.accessibilityLabel = @"Escape";
+
     // SF Symbols is cool
     if (@available(iOS 13, *)) {
         [self.infoButton setImage:[UIImage systemImageNamed:@"gear"] forState:UIControlStateNormal];
-        self.infoButton.accessibilityLabel = @"Settings";
         [self.pasteButton setImage:[UIImage systemImageNamed:@"doc.on.clipboard"] forState:UIControlStateNormal];
-        self.pasteButton.accessibilityLabel = @"Paste";
         [self.hideKeyboardButton setImage:[UIImage systemImageNamed:@"keyboard.chevron.compact.down"] forState:UIControlStateNormal];
-        self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
         
         [self.tabKey setTitle:nil forState:UIControlStateNormal];
         [self.tabKey setImage:[UIImage systemImageNamed:@"arrow.right.to.line.alt"] forState:UIControlStateNormal];
-        self.tabKey.accessibilityLabel = @"Tab";
         [self.controlKey setTitle:nil forState:UIControlStateNormal];
         [self.controlKey setImage:[UIImage systemImageNamed:@"control"] forState:UIControlStateNormal];
-        self.controlKey.accessibilityLabel = @"Control";
         [self.escapeKey setTitle:nil forState:UIControlStateNormal];
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
-        self.escapeKey.accessibilityLabel = @"Escape";
     }
     
     [UserPreferences.shared observe:@[@"hideStatusBar"] options:0 owner:self usingBlock:^(typeof(self) self) {


### PR DESCRIPTION
💡 What: Moved the assignment of VoiceOver accessibility labels for buttons like "Settings", "Paste", "Hide Keyboard", "Tab", "Control", and "Escape" outside the `@available(iOS 13, *)` block in `TerminalViewController.m`. Also added a learning entry to `.jules/palette.md`.
🎯 Why: These elements were previously nested inside an iOS 13+ version check along with SF Symbols, which meant screen reader users on older iOS versions wouldn't hear anything for these buttons.
♿ Accessibility: Ensures full VoiceOver support for terminal controls across all supported iOS versions.

---
*PR created automatically by Jules for task [8403535506284322768](https://jules.google.com/task/8403535506284322768) started by @emkey1*