### PR TITLE
🎨 Palette: Add accessibility selection traits to checkmarked table cells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2025-03-02 - Table Cell Checkmark Accessibility
+**Learning:** Adding `UITableViewCellAccessoryCheckmark` visually indicates selection but does not automatically notify VoiceOver users of the selected state.
+**Action:** Always manually toggle `UIAccessibilityTraitSelected` on `cell.accessibilityTraits` whenever `UITableViewCellAccessoryCheckmark` is toggled.

--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -218,7 +218,13 @@ enum {
                     cell.textLabel.text = @"Dark";
                     break;
             }
-            cell.accessoryType = indexPath.row == UserPreferences.shared.colorScheme ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            if (indexPath.row == UserPreferences.shared.colorScheme) {
+                cell.accessoryType = UITableViewCellAccessoryCheckmark;
+                cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            } else {
+                cell.accessoryType = UITableViewCellAccessoryNone;
+                cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+            }
             break;
             
         case CursorSection:

--- a/app/AboutExternalKeyboardViewController.m
+++ b/app/AboutExternalKeyboardViewController.m
@@ -54,10 +54,13 @@ const int kCapsLockMappingSection = 0;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping)
+    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    else
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 

--- a/app/ThemesViewController.m
+++ b/app/ThemesViewController.m
@@ -172,7 +172,15 @@ enum {
     }
     
     cell.textLabel.text = theme.name;
-    cell.accessoryType = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+
+    if ([theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection)) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
+
     cell.textLabel.enabled = ![theme.name isEqualToString:self->_theme.name] || indexPath.section != DefaultSection || !self->_preferUserTheme;
     cell.editingAccessoryType = UITableViewCellAccessoryDisclosureIndicator;
     


### PR DESCRIPTION
💡 What: The UX enhancement added: `UIAccessibilityTraitSelected` was applied to UITableViewCells configured with a visual checkmark (`UITableViewCellAccessoryCheckmark`) across the app's settings pages (Themes, Font Picker, Keyboard Mapping, Appearance).
🎯 Why: The user problem it solves: The default visual checkmark in iOS `UITableView` does not automatically update VoiceOver traits to say "Selected". This means screen reader users interacting with these option lists would not hear whether an option is currently the active one.
♿ Accessibility: Any a11y improvements made: Improved VoiceOver state awareness.

Note: Since cells are recycled in table views, `UIAccessibilityTraitSelected` is explicitly removed (`&= ~UIAccessibilityTraitSelected`) when the checkmark is absent. This guarantees correct readings for all items.

---
*PR created automatically by Jules for task [4038302356880335940](https://jules.google.com/task/4038302356880335940) started by @emkey1*