### PR TITLE
🎨 Palette: Add `UIAccessibilityTraitSelected` for checkmark cells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2024-05-25 - Table View Cell Checkmarks
+**Learning:** `UITableViewCellAccessoryCheckmark` does not automatically update accessibility traits to inform VoiceOver users that an item is selected. When using the checkmark accessory type to represent a selected state in a list, `UIAccessibilityTraitSelected` must be explicitly added to the cell's `accessibilityTraits`.
+**Action:** When setting `cell.accessoryType = UITableViewCellAccessoryCheckmark`, also set `cell.accessibilityTraits |= UIAccessibilityTraitSelected` (and clear it when not selected).

--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -218,7 +218,13 @@ enum {
                     cell.textLabel.text = @"Dark";
                     break;
             }
-            cell.accessoryType = indexPath.row == UserPreferences.shared.colorScheme ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            if (indexPath.row == UserPreferences.shared.colorScheme) {
+                cell.accessoryType = UITableViewCellAccessoryCheckmark;
+                cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            } else {
+                cell.accessoryType = UITableViewCellAccessoryNone;
+                cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+            }
             break;
             
         case CursorSection:

--- a/app/AboutExternalKeyboardViewController.m
+++ b/app/AboutExternalKeyboardViewController.m
@@ -54,10 +54,13 @@ const int kCapsLockMappingSection = 0;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping)
+    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    else
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 

--- a/app/ThemesViewController.m
+++ b/app/ThemesViewController.m
@@ -172,7 +172,13 @@ enum {
     }
     
     cell.textLabel.text = theme.name;
-    cell.accessoryType = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    if ([theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection)) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     cell.textLabel.enabled = ![theme.name isEqualToString:self->_theme.name] || indexPath.section != DefaultSection || !self->_preferUserTheme;
     cell.editingAccessoryType = UITableViewCellAccessoryDisclosureIndicator;
     


### PR DESCRIPTION
💡 **What:** Added `UIAccessibilityTraitSelected` explicitly to `UITableViewCell` instances that use `UITableViewCellAccessoryCheckmark` to denote a selected state. Modified view controllers include the font picker, keyboard settings, appearance settings, and themes. Unselected cells also explicitly clear this trait.
🎯 **Why:** While iOS renders a checkmark visually when `accessoryType` is set to `UITableViewCellAccessoryCheckmark`, this property alone does not inform screen readers like VoiceOver that the cell is in a selected state. This meant VoiceOver users wouldn't know which setting they currently had active. Explicitly setting the trait solves this.
📸 **Before/After:** No visual changes, strictly an accessibility improvement.
♿ **Accessibility:** Screen readers will now announce the selected setting correctly (e.g. "Selected, Dark, button"). Cell reuse is also safely handled by clearing the trait for non-selected cells.

---
*PR created automatically by Jules for task [16742785530040256758](https://jules.google.com/task/16742785530040256758) started by @emkey1*