### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in argv copy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-03-04 - Buffer Overflow in Command Line Arguments Parsing
+**Vulnerability:** In `xX_main_Xx.h`, the variable `argv_copy` was a fixed-size stack buffer of 4096 bytes used to flatten the command-line arguments array. The implementation repeatedly appended to this buffer via `memcpy` without verifying that the total size remained within the buffer limits.
+**Learning:** Functions that parse unbounded external inputs like command line parameters directly into static stack buffers often harbor simple stack buffer overflow vulnerabilities. Such inputs, while "trusted" in typical setups, can be exploited or cause crashes if artificially long strings are passed.
+**Prevention:** Always implement explicit bounds checking before sequentially writing to fixed-size buffers, particularly when combining or flattening arrays. Return a clear error like `_E2BIG` (Argument list too long) rather than truncating or overflowing.

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -99,6 +99,8 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     size_t p = 0;
     while (i < argc) {
         const size_t arg_len = strlen(argv[i]) + 1;
+        if (p + arg_len > sizeof(argv_copy) - 1)
+            return _E2BIG;
         memcpy(&argv_copy[p], argv[i], arg_len);
         p += arg_len;
         i++;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Buffer Overflow in `xX_main_Xx.h`. The variable `argv_copy` was a fixed-size stack buffer of 4096 bytes used to flatten the command-line arguments array. The implementation repeatedly appended to this buffer via `memcpy` without verifying that the total size remained within the buffer limits, allowing a stack buffer overflow.
🎯 Impact: An attacker could potentially gain arbitrary code execution or cause a denial of service (DoS) by passing excessively long command-line arguments.
🔧 Fix: Added an explicit bounds check inside the loop that concatenates the command-line arguments, returning `_E2BIG` (Argument list too long) if the buffer limit is exceeded.
✅ Verification: Verified syntax manually with gcc using `gcc -fsyntax-only xX_main_Xx.h -I. -D_GNU_SOURCE`.

---
*PR created automatically by Jules for task [14800511722474964217](https://jules.google.com/task/14800511722474964217) started by @emkey1*