### PR TITLE
🎨 Palette: Add VoiceOver selection traits to table view checkmarks

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2024-05-25 - UITableViewCell Checkmark Accessibility
+**Learning:** Using `UITableViewCellAccessoryCheckmark` visually indicates a selected state, but VoiceOver does not automatically announce this to users.
+**Action:** When using `UITableViewCellAccessoryCheckmark` in a `UITableView`, manually toggle `UIAccessibilityTraitSelected` on the cell to ensure the selection state is communicated to screen reader users.

--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -206,7 +206,7 @@ enum {
             }
             break;
             
-        case ColorSchemeSection:
+        case ColorSchemeSection: {
             switch (indexPath.row) {
                 case 0:
                     cell.textLabel.text = @"Match System";
@@ -218,8 +218,15 @@ enum {
                     cell.textLabel.text = @"Dark";
                     break;
             }
-            cell.accessoryType = indexPath.row == UserPreferences.shared.colorScheme ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            BOOL selected = indexPath.row == UserPreferences.shared.colorScheme;
+            cell.accessoryType = selected ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            if (selected) {
+                cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            } else {
+                cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+            }
             break;
+        }
             
         case CursorSection:
         case StatusBarSection:

--- a/app/AboutExternalKeyboardViewController.m
+++ b/app/AboutExternalKeyboardViewController.m
@@ -54,10 +54,14 @@ const int kCapsLockMappingSection = 0;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping)
+    BOOL selected = indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping;
+    if (selected) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    else
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
-        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+    BOOL selected = [family isEqualToString:UserPreferences.shared.fontFamily];
+    cell.accessoryType = selected ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    if (selected) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 

--- a/app/ThemesViewController.m
+++ b/app/ThemesViewController.m
@@ -172,7 +172,13 @@ enum {
     }
     
     cell.textLabel.text = theme.name;
-    cell.accessoryType = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    BOOL selected = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection);
+    cell.accessoryType = selected ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    if (selected) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     cell.textLabel.enabled = ![theme.name isEqualToString:self->_theme.name] || indexPath.section != DefaultSection || !self->_preferUserTheme;
     cell.editingAccessoryType = UITableViewCellAccessoryDisclosureIndicator;
     


### PR DESCRIPTION
💡 What: Added manual toggling of `UIAccessibilityTraitSelected` for table view cells that use `UITableViewCellAccessoryCheckmark` to indicate a selected state.
🎯 Why: VoiceOver does not automatically announce that a cell is "Selected" merely because it has a checkmark accessory. This ensures screen reader users receive the same state information as visual users.
♿ Accessibility: Improves accessibility in Settings by clearly communicating the active state of configurable options (Fonts, Color Schemes, Themes, Caps Lock Mapping).

Relevant files updated:
- `app/AboutAppearanceViewController.m`
- `app/AboutExternalKeyboardViewController.m`
- `app/FontPickerViewController.m`
- `app/ThemesViewController.m`
- `.jules/palette.md`

---
*PR created automatically by Jules for task [12423330324671058384](https://jules.google.com/task/12423330324671058384) started by @emkey1*