### PR TITLE
⚡ Bolt: Optimize sys_getcwd by removing unnecessary heap allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Kernel Stack Limitations
 **Learning:** Allocating large buffers (e.g., 4096 bytes) directly on the kernel stack in `kernel/fs.c` (like inside `sys_read`) will cause kernel stack overflow. In this architecture, the kernel stack is small and bounded.
 **Action:** When optimizing away `malloc` calls for small operations in the kernel, limit stack-allocated buffers to small, safe sizes like 256 bytes and fall back to heap allocation for larger requests.
+
+## 2024-05-27 - Unnecessary Allocation in sys_getcwd
+**Learning:** The implementation of `sys_getcwd` allocated a heap buffer simply to copy the stack buffer `pwd` before writing it to user space. This is an unnecessary `malloc`/`free` cycle and a redundant string copy, since `user_write` can read directly from the stack buffer.
+**Action:** Eliminate the heap allocation and copy by using `pwd` directly in the `user_write` call. This reduces memory pressure and execution time.

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -643,19 +643,14 @@ dword_t sys_getcwd(addr_t buf_addr, dword_t size) {
     if (err < 0)
         return err;
 
-    if (strlen(pwd) + 1 > size)
+    size_t pwd_len = strlen(pwd) + 1;
+    if (pwd_len > size)
         return _ERANGE;
-    size = strlen(pwd) + 1;
-    char *buf = malloc(size);
-    if (buf == NULL)
-        return _ENOMEM;
-    strcpy(buf, pwd);
-    STRACE(" \"%.*s\"", size, buf);
-    dword_t res = size;
-    if (user_write(buf_addr, buf, size))
-        res = _EFAULT;
-    free(buf);
-    return res;
+
+    STRACE(" \"%.*s\"", (int)pwd_len, pwd);
+    if (user_write(buf_addr, pwd, pwd_len))
+        return _EFAULT;
+    return pwd_len;
 }
 
 static struct fd *open_dir(const char *path) {


### PR DESCRIPTION
💡 What: The optimization removes an unnecessary heap allocation and memory copy in `sys_getcwd` inside `kernel/fs.c`. Instead of allocating `buf` to copy `pwd` and write it, `user_write` uses `pwd` directly.

🎯 Why: The previous implementation needlessly incurred `malloc` and `free` overhead along with an extra `strcpy`. The `pwd` array is already allocated safely on the stack as `char pwd[MAX_PATH + 1];` and populated via `generic_getpath`. Passing it directly to `user_write` avoids heap fragmentation and reduces the execution cost of `sys_getcwd`.

📊 Impact: Speeds up the `getcwd` syscall execution time. Reduces memory overhead by omitting dynamic heap allocations for path buffer retrieval.

🔬 Measurement: Benchmark the execution of `getcwd` system calls. Verify successful operation using standard core utilities (e.g. running `pwd` in the shell) and observe correct system output behavior. Tested syntax correctly with `gcc -fsyntax-only`.

---
*PR created automatically by Jules for task [8833789366864369558](https://jules.google.com/task/8833789366864369558) started by @emkey1*