### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in command-line argument copy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-03-06 - Buffer Overflow in Command-Line Arguments Parsing
+**Vulnerability:** In `xX_main_Xx.h`, command line arguments (`argv`) are flattened into a stack-allocated 4096-byte buffer `argv_copy`. The loop copies each argument string via `memcpy` and increments an index `p`, but there was no check to ensure `p + arg_len` did not exceed the size of the buffer. An attacker providing many large arguments could trigger a stack-based buffer overflow, overwriting return addresses or neighboring stack variables.
+**Learning:** Even simple setup routines or loop-based string copies must enforce length bounds on the destination buffer. Assuming `argv` size is inherently limited (or smaller than 4K) is unsafe, as user-provided arguments can easily exceed this limit.
+**Prevention:** Always maintain and check the remaining capacity in destination buffers during loop-based concatenations or copies. Return a clear error like `_E2BIG` (Argument list too long) when boundaries are exceeded.

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -99,6 +99,8 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     size_t p = 0;
     while (i < argc) {
         const size_t arg_len = strlen(argv[i]) + 1;
+        if (p + arg_len > sizeof(argv_copy) - 1)
+            return _E2BIG;
         memcpy(&argv_copy[p], argv[i], arg_len);
         p += arg_len;
         i++;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A stack-based buffer overflow existed in `xX_main_Xx.h` when command-line arguments (`argv`) are flattened into the stack-allocated 4096-byte buffer `argv_copy`. The loop copied each string sequentially without ensuring `p + arg_len` did not exceed `sizeof(argv_copy)`.
🎯 Impact: An attacker or process could provide an excessively long list of command line arguments, causing the `memcpy` to write out of the `argv_copy` array bounds, overwriting adjacent memory on the stack (potentially leading to a crash or code execution).
🔧 Fix: Added a bounds check `if (p + arg_len > sizeof(argv_copy) - 1)` prior to the `memcpy` operation inside the `while (i < argc)` loop. If the threshold is exceeded, the function securely aborts and returns the `_E2BIG` (Argument list too long) error code.
✅ Verification: Compiled successfully with `gcc -fsyntax-only` and verified logic with a standalone C mock script mimicking the loop.

This also adds a note in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9232093332376796804](https://jules.google.com/task/9232093332376796804) started by @emkey1*