### PR TITLE
🎨 Palette: Improve table view cell accessibility and reuse state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2024-05-25 - UITableViewCell State Reuse and Accessibility
+**Learning:** When reusing `UITableViewCell`s with checkmarks (`UITableViewCellAccessoryCheckmark`), failing to explicitly clear the accessory type for unselected cells causes visual bugs when scrolling. Furthermore, relying only on the visual checkmark leaves VoiceOver users unaware of the selection state.
+**Action:** Always explicitly set `accessoryType` to `UITableViewCellAccessoryNone` for unselected recycled cells. Simultaneously, toggle `UIAccessibilityTraitSelected` (using `|=` to set and `&= ~` to clear) alongside the checkmark to ensure screen reader users receive accurate selection feedback.

--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -218,7 +218,13 @@ enum {
                     cell.textLabel.text = @"Dark";
                     break;
             }
-            cell.accessoryType = indexPath.row == UserPreferences.shared.colorScheme ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            if (indexPath.row == UserPreferences.shared.colorScheme) {
+                cell.accessoryType = UITableViewCellAccessoryCheckmark;
+                cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            } else {
+                cell.accessoryType = UITableViewCellAccessoryNone;
+                cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+            }
             break;
             
         case CursorSection:

--- a/app/AboutExternalKeyboardViewController.m
+++ b/app/AboutExternalKeyboardViewController.m
@@ -54,10 +54,13 @@ const int kCapsLockMappingSection = 0;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping)
+    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    else
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 

--- a/app/ThemesViewController.m
+++ b/app/ThemesViewController.m
@@ -172,7 +172,13 @@ enum {
     }
     
     cell.textLabel.text = theme.name;
-    cell.accessoryType = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    if ([theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection)) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     cell.textLabel.enabled = ![theme.name isEqualToString:self->_theme.name] || indexPath.section != DefaultSection || !self->_preferUserTheme;
     cell.editingAccessoryType = UITableViewCellAccessoryDisclosureIndicator;
     


### PR DESCRIPTION
💡 **What:** Explicitly clear `accessoryType` and toggle `UIAccessibilityTraitSelected` for reused `UITableViewCell` instances.
🎯 **Why:** Reusing cells with checkmarks without resetting the state causes visual bugs when scrolling. Moreover, VoiceOver users won't know the selection state unless `UIAccessibilityTraitSelected` is explicitly applied.
📸 **Before/After:** No visual changes, strictly internal cell reuse fixes and accessibility traits.
♿ **Accessibility:** Added `UIAccessibilityTraitSelected` to cells displaying a checkmark so screen reader users hear "Selected".

---
*PR created automatically by Jules for task [17941481185403711203](https://jules.google.com/task/17941481185403711203) started by @emkey1*