### PR TITLE
🎨 Palette: Fix checkmark selection state for VoiceOver on recycled table cells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2024-05-25 - UITableViewCell Selection Accessibility and Reuse
+**Learning:** When managing state for reused `UITableViewCell` instances in iOS, relying only on `accessoryType` for visual state is insufficient for screen readers, and failing to clear state on unselected cells causes UI bugs when cells are recycled. VoiceOver users may not be aware of selection states indicated by checkmarks if traits are not updated.
+**Action:** Always explicitly reset `accessoryType` to `UITableViewCellAccessoryNone` and clear the `UIAccessibilityTraitSelected` trait (`cell.accessibilityTraits &= ~UIAccessibilityTraitSelected`) for unselected cells, while setting the selected trait when `UITableViewCellAccessoryCheckmark` is used.

--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -218,7 +218,13 @@ enum {
                     cell.textLabel.text = @"Dark";
                     break;
             }
-            cell.accessoryType = indexPath.row == UserPreferences.shared.colorScheme ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            if (indexPath.row == UserPreferences.shared.colorScheme) {
+                cell.accessoryType = UITableViewCellAccessoryCheckmark;
+                cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            } else {
+                cell.accessoryType = UITableViewCellAccessoryNone;
+                cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+            }
             break;
             
         case CursorSection:

--- a/app/AboutExternalKeyboardViewController.m
+++ b/app/AboutExternalKeyboardViewController.m
@@ -54,10 +54,13 @@ const int kCapsLockMappingSection = 0;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping)
+    if (indexPath.section == kCapsLockMappingSection && cell.tag == UserPreferences.shared.capsLockMapping) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    else
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
         cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 

--- a/app/ThemesViewController.m
+++ b/app/ThemesViewController.m
@@ -172,7 +172,13 @@ enum {
     }
     
     cell.textLabel.text = theme.name;
-    cell.accessoryType = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    if ([theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection)) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     cell.textLabel.enabled = ![theme.name isEqualToString:self->_theme.name] || indexPath.section != DefaultSection || !self->_preferUserTheme;
     cell.editingAccessoryType = UITableViewCellAccessoryDisclosureIndicator;
     


### PR DESCRIPTION
💡 **What**: Added logic to explicitly add `UIAccessibilityTraitSelected` to `UITableViewCell` instances when they are selected (i.e. having `UITableViewCellAccessoryCheckmark`) and removed it when unselected. Added explicit clearance of the `accessoryType` for unselected cells to ensure proper recycling behavior.
🎯 **Why**: When configuring themes, font, appearance, and keyboard settings, VoiceOver users need to hear that an option is selected. Relying solely on `accessoryType = UITableViewCellAccessoryCheckmark` does not automatically update accessibility traits in all instances, especially for cells that are frequently recycled by `UITableView`. Failing to clean up unselected cells leads to recycled cells inaccurately announcing themselves as selected. 
♿ **Accessibility**: Directly sets the correct `UIAccessibilityTraitSelected` mask on selected table cells, fixing bugs where VoiceOver was unaware of the selection states on recycled cells.

---
*PR created automatically by Jules for task [2026573494730354438](https://jules.google.com/task/2026573494730354438) started by @emkey1*