### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix kernel stack overflow in shebang_exec

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-02-24 - Kernel Stack DoS via Large Stack Allocations
+**Vulnerability:** A local variable `char new_argv_buf[ARGV_MAX];` allocated 128KB on the kernel stack in `shebang_exec` (`kernel/exec.c`). Given strict kernel stack limits, an attacker could trigger a stack overflow by executing a shebang script, leading to a Denial of Service (DoS) or potential arbitrary code execution within the kernel environment.
+**Learning:** Massive constants like `ARGV_MAX` (128KB) should never be used to allocate arrays on the stack due to tight stack limitations, even for short-lived operations.
+**Prevention:** Large buffers must be dynamically allocated on the heap using `malloc()` with proper `NULL` checks, and they must be freed on all execution paths to prevent memory leaks while avoiding stack overflow DoS vulnerabilities.

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -544,7 +544,9 @@ static int shebang_exec(struct fd *fd, const char *file, struct exec_args argv, 
     if (args_rest_size + extra_args_size >= ARGV_MAX)
         return _E2BIG;
 
-    char new_argv_buf[ARGV_MAX];
+    char *new_argv_buf = malloc(ARGV_MAX);
+    if (new_argv_buf == NULL)
+        return _ENOMEM;
     struct exec_args new_argv = {.args = new_argv_buf};
     size_t n = 0;
     strcpy(new_argv_buf, interpreter);
@@ -562,10 +564,13 @@ static int shebang_exec(struct fd *fd, const char *file, struct exec_args argv, 
     new_argv.count += argv_rest.count;
 
     struct fd *interpreter_fd = generic_open(interpreter, O_RDONLY_, 0);
-    if (IS_ERR(interpreter_fd))
+    if (IS_ERR(interpreter_fd)) {
+        free(new_argv_buf);
         return (int)PTR_ERR(interpreter_fd);
+    }
     int err = format_exec(interpreter_fd, interpreter, new_argv, envp);
     fd_close(interpreter_fd);
+    free(new_argv_buf);
     return err;
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix kernel stack overflow DoS in shebang_exec

*   **Severity:** CRITICAL
*   **Vulnerability:** `shebang_exec` allocated a 128KB buffer (`char new_argv_buf[ARGV_MAX]`) directly on the kernel stack, creating a high risk of stack overflow and Denial of Service (DoS) when executing shebang scripts with long arguments.
*   **Impact:** A local attacker could construct an executable file and invoke it with extensive arguments to trigger a kernel panic due to stack exhaustion.
*   **Fix:** Replaced the static stack allocation with dynamic heap allocation (`malloc()`). Added standard error handling for out-of-memory conditions (`_ENOMEM`) and ensured the heap buffer is reliably freed (`free()`) on both success and error exit paths.
*   **Verification:** Verified via static syntax checking and manual code review to ensure the heap allocation logic correctly mirrors the previous stack manipulation without introducing memory leaks. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7365281753072033658](https://jules.google.com/task/7365281753072033658) started by @emkey1*