### PR TITLE
⚡ Bolt: Optimize readv/writev with stack buffer for small I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Kernel Stack Limitations
 **Learning:** Allocating large buffers (e.g., 4096 bytes) directly on the kernel stack in `kernel/fs.c` (like inside `sys_read`) will cause kernel stack overflow. In this architecture, the kernel stack is small and bounded.
 **Action:** When optimizing away `malloc` calls for small operations in the kernel, limit stack-allocated buffers to small, safe sizes like 256 bytes and fall back to heap allocation for larger requests.
+
+## 2024-05-25 - sys_readv and sys_writev performance
+**Learning:** System calls `sys_readv` and `sys_writev` in `kernel/fs.c` flatten vectorized I/O requests into a single buffer. Before, they always used `malloc()` to allocate this buffer, regardless of the size. This incurs significant performance overhead for small readv/writev calls which are very common.
+**Action:** Implemented a fast path using an explicitly aligned `256`-byte stack buffer for small `sys_readv` and `sys_writev` requests, similar to existing optimizations in `sys_read`, `sys_write`, `sys_pread` and `sys_pwrite`. Only requests larger than 256 bytes will now fall back to heap allocation. Added `__attribute__((aligned(16)))` to stack buffers for consistency.

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -263,7 +263,7 @@ dword_t sys_read(fd_t fd_no, addr_t buf_addr, dword_t size) {
     if (size > MAX_RW_COUNT)
         size = MAX_RW_COUNT;
 
-    char stack_buf[256];
+    char stack_buf[256] __attribute__((aligned(16)));
     char *buf = stack_buf;
     if (size > sizeof(stack_buf)) {
         buf = (char *) malloc(size);
@@ -309,7 +309,7 @@ dword_t sys_write(fd_t fd_no, addr_t buf_addr, dword_t size) {
     if (size > MAX_RW_COUNT)
         size = MAX_RW_COUNT;
 
-    char stack_buf[256];
+    char stack_buf[256] __attribute__((aligned(16)));
     char *buf = stack_buf;
     if (size > sizeof(stack_buf)) {
         buf = malloc(size);
@@ -372,10 +372,14 @@ dword_t sys_readv(fd_t fd_no, addr_t iovec_addr, dword_t iovec_count) {
     size_t io_size = iovec_size(iovec, iovec_count);
     if (io_size > MAX_RW_COUNT)
         io_size = MAX_RW_COUNT;
-    char *buf = malloc(io_size);
-    if (buf == NULL) {
-        free(iovec);
-        return _ENOMEM;
+    char stack_buf[256] __attribute__((aligned(16)));
+    char *buf = stack_buf;
+    if (io_size > sizeof(stack_buf)) {
+        buf = malloc(io_size);
+        if (buf == NULL) {
+            free(iovec);
+            return _ENOMEM;
+        }
     }
     ssize_t res = 0;
     TASK_MAY_BLOCK {
@@ -404,7 +408,7 @@ dword_t sys_readv(fd_t fd_no, addr_t iovec_addr, dword_t iovec_count) {
     }
 
 error:
-    free(buf);
+    if (buf != stack_buf) free(buf);
     free(iovec);
     return res;
 }
@@ -417,10 +421,14 @@ dword_t sys_writev(fd_t fd_no, addr_t iovec_addr, dword_t iovec_count) {
     size_t io_size = iovec_size(iovec, iovec_count);
     if (io_size > MAX_RW_COUNT)
         io_size = MAX_RW_COUNT;
-    char *buf = malloc(io_size);
-    if (buf == NULL) {
-        free(iovec);
-        return _ENOMEM;
+    char stack_buf[256] __attribute__((aligned(16)));
+    char *buf = stack_buf;
+    if (io_size > sizeof(stack_buf)) {
+        buf = malloc(io_size);
+        if (buf == NULL) {
+            free(iovec);
+            return _ENOMEM;
+        }
     }
 
     ssize_t res = 0;
@@ -446,7 +454,7 @@ dword_t sys_writev(fd_t fd_no, addr_t iovec_addr, dword_t iovec_count) {
         res = sys_write_buf(fd_no, buf, offset);
     }
 error:
-    free(buf);
+    if (buf != stack_buf) free(buf);
     free(iovec);
     return res;
 }
@@ -492,7 +500,7 @@ dword_t sys_pread(fd_t f, addr_t buf_addr, dword_t size, off_t_ off) {
     if (fd == NULL)
         return _EBADF;
 
-    char stack_buf[256];
+    char stack_buf[256] __attribute__((aligned(16)));
     char *buf = stack_buf;
     if (size >= sizeof(stack_buf)) {
         buf = malloc(size+1);
@@ -539,7 +547,7 @@ dword_t sys_pwrite(fd_t f, addr_t buf_addr, dword_t size, off_t_ off) {
     if (fd == NULL)
         return _EBADF;
 
-    char stack_buf[256];
+    char stack_buf[256] __attribute__((aligned(16)));
     char *buf = stack_buf;
     if (size >= sizeof(stack_buf)) {
         buf = malloc(size+1);


### PR DESCRIPTION
💡 **What**: Optimized `sys_readv` and `sys_writev` system calls in `kernel/fs.c` by introducing an explicitly aligned 256-byte stack buffer for small payload sizes, similar to how `sys_read` and `sys_write` operate. 
🎯 **Why**: Previously, `sys_readv` and `sys_writev` explicitly called `malloc()` to flatten the I/O vector, regardless of size. This introduced considerable performance overhead due to the constant dynamic memory allocation and deallocation for small, frequent vector operations.
📊 **Impact**: Expected noticeable decrease in the latency of small vector I/O operations and an overall reduction in kernel heap fragmentation.
🔬 **Measurement**: Use standard POSIX readv/writev benchmarking suites internally or monitor I/O syscall latency within the application runtime.

---
*PR created automatically by Jules for task [1423370370246237998](https://jules.google.com/task/1423370370246237998) started by @emkey1*