### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack allocation DoS in kernel/exec.c

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-03-09 - [Massive stack allocation in shebang_exec DoS]
+**Vulnerability:** A massive 128KB stack buffer (`char new_argv_buf[ARGV_MAX];`) was allocated in `kernel/exec.c` during `shebang_exec`.
+**Learning:** In the iSH kernel environment, allocating large arrays like `ARGV_MAX` (128KB) on the stack is a critical anti-pattern and can cause stack overflows and Denial of Service (DoS) due to small kernel stack limits.
+**Prevention:** Always use dynamic heap allocation (e.g., `malloc(ARGV_MAX)`) for large buffers, check for `NULL`, and explicitly `free` the buffer on all return paths.

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -544,7 +544,10 @@ static int shebang_exec(struct fd *fd, const char *file, struct exec_args argv, 
     if (args_rest_size + extra_args_size >= ARGV_MAX)
         return _E2BIG;
 
-    char new_argv_buf[ARGV_MAX];
+    char *new_argv_buf = malloc(ARGV_MAX);
+    if (new_argv_buf == NULL)
+        return _ENOMEM;
+
     struct exec_args new_argv = {.args = new_argv_buf};
     size_t n = 0;
     strcpy(new_argv_buf, interpreter);
@@ -562,10 +565,13 @@ static int shebang_exec(struct fd *fd, const char *file, struct exec_args argv, 
     new_argv.count += argv_rest.count;
 
     struct fd *interpreter_fd = generic_open(interpreter, O_RDONLY_, 0);
-    if (IS_ERR(interpreter_fd))
+    if (IS_ERR(interpreter_fd)) {
+        free(new_argv_buf);
         return (int)PTR_ERR(interpreter_fd);
+    }
     int err = format_exec(interpreter_fd, interpreter, new_argv, envp);
     fd_close(interpreter_fd);
+    free(new_argv_buf);
     return err;
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix massive stack allocation DoS in kernel/exec.c

🚨 Severity: CRITICAL
💡 Vulnerability: `shebang_exec` allocated `char new_argv_buf[ARGV_MAX];` on the stack. `ARGV_MAX` is 128KB (32 * 4096), which far exceeds kernel stack limitations and leads to stack overflows causing a Denial of Service (DoS) vulnerability.
🎯 Impact: Unprivileged users executing scripts could crash the application by triggering a kernel stack overflow.
🔧 Fix: Replaced the massive stack allocation with dynamic heap allocation (`malloc(ARGV_MAX)`). Added a `NULL` check to return `_ENOMEM` on failure, and ensured `free(new_argv_buf)` is called on all success and error return paths.
✅ Verification: Tested C syntax using `gcc -fsyntax-only`. Code review approved. Added journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13493793289621999407](https://jules.google.com/task/13493793289621999407) started by @emkey1*