### PR TITLE
⚡ Bolt: Remove redundant malloc/free in sys_getcwd

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -646,15 +646,13 @@ dword_t sys_getcwd(addr_t buf_addr, dword_t size) {
     if (strlen(pwd) + 1 > size)
         return _ERANGE;
     size = strlen(pwd) + 1;
-    char *buf = malloc(size);
-    if (buf == NULL)
-        return _ENOMEM;
-    strcpy(buf, pwd);
-    STRACE(" \"%.*s\"", size, buf);
+
+    // ⚡ Bolt: Removed redundant malloc/strcpy/free. `pwd` is already
+    // safely allocated on the stack (MAX_PATH + 1 size) and contains the string.
+    STRACE(" \"%.*s\"", size, pwd);
     dword_t res = size;
-    if (user_write(buf_addr, buf, size))
+    if (user_write(buf_addr, pwd, size))
         res = _EFAULT;
-    free(buf);
     return res;
 }
 


### PR DESCRIPTION
**💡 What:** 
Removed redundant `malloc`, `strcpy`, and `free` sequence in `sys_getcwd` (`kernel/fs.c`). The function was copying an existing stack-allocated buffer into a newly allocated heap buffer just to write it to user space.

**🎯 Why:**
This removes unnecessary overhead. The `pwd` buffer is already correctly bounded on the stack to `MAX_PATH + 1` and contains the target string. The heap allocation was pure waste and added slight risk of memory fragmentation for a common I/O operation.

**📊 Impact:** 
Saves CPU cycles, reduces heap fragmentation, and simplifies the codebase by eliminating unnecessary `malloc`/`free` loops during `getcwd` system calls. Completely architecturally safe since `user_write` can handle stack addresses directly.

**🔬 Measurement:**
Tested locally with a standalone mock validating exact behavior, correctness of parameters passed to `user_write`, and verifying early return code (`_ERANGE`) functions identically without regression.

---
*PR created automatically by Jules for task [12306305970608929270](https://jules.google.com/task/12306305970608929270) started by @emkey1*