### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack overflow in shebang_exec

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-02-24 - Massive Kernel Stack Allocation
+**Vulnerability:** A massive constant `ARGV_MAX` (128 KB) was used to size a static array (`char new_argv_buf[ARGV_MAX];`) allocated on the stack in `kernel/exec.c`'s `shebang_exec`. In kernel-space with small stack limits, this causes a stack overflow (DoS / crash vulnerability).
+**Learning:** Massive macro constants defined as bounds limits should never be mapped 1:1 to stack array allocations without checking their actual size.
+**Prevention:** For large allocations (e.g. anything over a few KB), always use heap allocation (`malloc`), check for `NULL`, and `free` correctly on all execution paths.

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -544,7 +544,10 @@ static int shebang_exec(struct fd *fd, const char *file, struct exec_args argv, 
     if (args_rest_size + extra_args_size >= ARGV_MAX)
         return _E2BIG;
 
-    char new_argv_buf[ARGV_MAX];
+    char *new_argv_buf = malloc(ARGV_MAX);
+    if (new_argv_buf == NULL)
+        return _ENOMEM;
+
     struct exec_args new_argv = {.args = new_argv_buf};
     size_t n = 0;
     strcpy(new_argv_buf, interpreter);
@@ -561,11 +564,16 @@ static int shebang_exec(struct fd *fd, const char *file, struct exec_args argv, 
     memcpy(new_argv_buf + n, argv_rest.args, args_rest_size);
     new_argv.count += argv_rest.count;
 
+    int err;
     struct fd *interpreter_fd = generic_open(interpreter, O_RDONLY_, 0);
-    if (IS_ERR(interpreter_fd))
-        return (int)PTR_ERR(interpreter_fd);
-    int err = format_exec(interpreter_fd, interpreter, new_argv, envp);
-    fd_close(interpreter_fd);
+    if (IS_ERR(interpreter_fd)) {
+        err = (int)PTR_ERR(interpreter_fd);
+    } else {
+        err = format_exec(interpreter_fd, interpreter, new_argv, envp);
+        fd_close(interpreter_fd);
+    }
+
+    free(new_argv_buf);
     return err;
 }
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A buffer of 128KB (`ARGV_MAX`) was being allocated on the kernel stack inside the `shebang_exec` function. Kernel stacks are extremely small, meaning this large allocation would instantly overflow the stack and cause a severe crash or Denial of Service (DoS), potentially being leveraged for arbitrary code execution.
🎯 **Impact**: Denial of Service (DoS) / Kernel Panic via stack overflow when parsing a shebang script.
🔧 **Fix**: Changed `char new_argv_buf[ARGV_MAX];` to dynamically allocate the buffer on the heap using `malloc(ARGV_MAX)`. Added a `NULL` pointer check to return `_ENOMEM` correctly and ensure the buffer is `free()`d before the function exits in all scenarios.
✅ **Verification**: Compiled with `gcc -fsyntax-only kernel/exec.c -I. -D_GNU_SOURCE -include string.h` to ensure no syntax or C compilation errors were introduced. Checked return paths carefully to ensure no memory leaks (`free` is always called).

---
*PR created automatically by Jules for task [4061860890051906649](https://jules.google.com/task/4061860890051906649) started by @emkey1*