### PR TITLE
⚡ Bolt: Optimize VFS path resolution string length logic

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Kernel Stack Limitations
 **Learning:** Allocating large buffers (e.g., 4096 bytes) directly on the kernel stack in `kernel/fs.c` (like inside `sys_read`) will cause kernel stack overflow. In this architecture, the kernel stack is small and bounded.
 **Action:** When optimizing away `malloc` calls for small operations in the kernel, limit stack-allocated buffers to small, safe sizes like 256 bytes and fall back to heap allocation for larger requests.
+
+## 2024-05-25 - Caching String Lengths for Fast Path Resolution
+**Learning:** Hot paths like `mount_find` in `fs/mount.c` recalculate string lengths in loops (`strlen(mount->point)`). This is O(N) over path length per mount checked and significantly slows down VFS operations.
+**Action:** When iterating over lists of paths, strings, or mount points, prefer pre-calculating and caching their lengths. The length can be stored inside structs like `struct mount` (e.g. `point_len`) upon initialization, turning subsequent length checks into O(1) reads.

--- a/fs/generic.c
+++ b/fs/generic.c
@@ -22,8 +22,8 @@ struct mount *find_mount_and_trim_path(char *path) {
 
 bool contains_mount_point(const char *path) {
     struct mount *mount;
+    int n = strlen(path); // ⚡ Bolt: Hoist string length calculation outside the loop
     list_for_each_entry(&mounts, mount, mounts) {
-        int n = strlen(path);
         if (strncmp(path, mount->point, n) == 0 &&
                 (mount->point[n] == '\0' || mount->point[n] == '/'))
             return true;

--- a/fs/mount.c
+++ b/fs/mount.c
@@ -44,7 +44,7 @@ struct mount *mount_find(char *path) {
     struct mount *mount = NULL;
     assert(!list_empty(&mounts)); // this would mean there's no root FS mounted
     list_for_each_entry(&mounts, mount, mounts) {
-        size_t n = strlen(mount->point);
+        size_t n = mount->point_len; // ⚡ Bolt: Use cached length instead of strlen
         if (strncmp(path, mount->point, n) == 0 && (path[n] == '/' || path[n] == '\0'))
             break;
     }
@@ -90,7 +90,7 @@ int do_mount(const struct fs_ops *fs, const char *source, const char *point, con
     // the list must stay in descending order of mount point length
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
-        if (strlen(mount->point) <= strlen(new_mount->point))
+        if (mount->point_len <= new_mount->point_len) // ⚡ Bolt: Use cached lengths
             break;
     }
     list_add_before(&mount->mounts, &new_mount->mounts);


### PR DESCRIPTION
💡 **What:** 
Replaced repeated `strlen()` calls inside tight list iteration loops for mount points with pre-calculated lengths. Specifically:
1. Replaced `strlen(mount->point)` with the cached `mount->point_len` inside `mount_find` and `do_mount` (`fs/mount.c`).
2. Hoisted `int n = strlen(path)` outside the `list_for_each_entry` loop in `contains_mount_point` (`fs/generic.c`).

🎯 **Why:** 
`mount_find` is a critical hot path involved in almost all path resolution operations. Previously, it iterated through the list of mounts, running `strlen` on every mount's point path at each check. This degraded performance linearly as paths lengthened or mount lists grew. `contains_mount_point` suffered from the same repeated string traversal.

📊 **Impact:** 
Transforms path length calculation from O(N * L) (where N is the number of mounts and L is string length) to O(1) inside loop bodies, reducing CPU cycles during filesystem operations, particularly path normalization, rename, and rmdir.

🔬 **Measurement:** 
I verified changes using `gcc -fsyntax-only` to ensure syntactical correctness since the full build tools are missing from the current environment. The e2e test suite (`tests/e2e/e2e.bash`) failed to run due to missing the built `ish` binary. The tests logic remains unaffected because the underlying check variables are structurally identical.

---
*PR created automatically by Jules for task [18084661892946261052](https://jules.google.com/task/18084661892946261052) started by @emkey1*