### PR TITLE
🎨 Palette: Improve font picker VoiceOver selection & visual cell reuse state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2025-01-20 - Cell Reuse and Accessibility State
+**Learning:** Reusing `UITableViewCell` instances without explicitly resetting `accessoryType` to `None` and clearing `UIAccessibilityTraitSelected` can cause incorrect UI states and misleading VoiceOver announcements on recycled cells.
+**Action:** Always ensure that both visual state (e.g. checkmarks) and accessibility traits are completely reset for unselected states in `cellForRowAtIndexPath`.

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 What: Explicitly resets `accessoryType` and `UIAccessibilityTraitSelected` for unselected recycled cells in `FontPickerViewController.m`.
🎯 Why: To prevent unselected fonts from incorrectly showing checkmarks or announcing as selected by VoiceOver when scrolling reuses previously selected cells.
♿ Accessibility: Fixes misleading VoiceOver readouts for standard list selections, ensuring proper screen reader navigation.

---
*PR created automatically by Jules for task [16862585055024111909](https://jules.google.com/task/16862585055024111909) started by @emkey1*