### PR TITLE
🛡️ Sentinel: [HIGH] Fix stack buffer overflow in xX_main_Xx.h

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## $(date +%Y-%m-%d) - Fix stack buffer overflow in `xX_main_Xx.h`
+**Vulnerability:** A `memcpy` call in `xX_main_Xx` was copying command line arguments into a fixed 4096 byte stack buffer `argv_copy` without checking the remaining buffer space. If the arguments were larger than 4096 bytes, a stack buffer overflow would occur.
+**Learning:** Command-line argument copying in `xX_main_Xx.h` into the `argv_copy` stack buffer requires explicit bounds checking against its 4096-byte limit to prevent stack buffer overflows from `argv`.
+**Prevention:** Always verify `len < max_size` when appending or copying dynamically sized strings to static buffers. Return standard error code like `_E2BIG` (Argument list too long) when boundaries are exceeded.

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -99,6 +99,8 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     size_t p = 0;
     while (i < argc) {
         const size_t arg_len = strlen(argv[i]) + 1;
+        if (p + arg_len >= sizeof(argv_copy))
+            return _E2BIG;
         memcpy(&argv_copy[p], argv[i], arg_len);
         p += arg_len;
         i++;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `xX_main_Xx` function in `xX_main_Xx.h` copies command-line arguments into a 4096-byte stack buffer (`argv_copy`) using a `while` loop and `memcpy` without bounds checking. Providing a command line payload exceeding 4096 bytes would trigger a stack buffer overflow.
🎯 Impact: A malicious user or process could construct an oversized argument list to overwrite the execution stack, potentially leading to arbitrary code execution or a Denial of Service (DoS).
🔧 Fix: Added bounds checking logic `if (p + arg_len >= sizeof(argv_copy))` inside the copy loop to verify the buffer size limit is respected. If the limit is reached or exceeded, the process returns the POSIX error `_E2BIG` (Argument list too long), failing securely.
✅ Verification: Tested syntax checking to ensure changes didn't affect compilation logic. Also, an e2e test or manual testing by starting the program with excessively long arguments would fail safely instead of crashing.

---
*PR created automatically by Jules for task [5716673193404330260](https://jules.google.com/task/5716673193404330260) started by @emkey1*