### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack buffer overflow in argv

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2026-03-12 - Stack Buffer Overflow in Command-Line Arguments
+**Vulnerability:** In `xX_main_Xx.h`, the loop copying command-line arguments into the fixed-size 4096-byte `argv_copy` stack buffer lacked bounds checking. An adversary or script passing sufficiently long arguments could trigger a stack buffer overflow.
+**Learning:** Even internal initialization logic and argument passing functions are susceptible to bounds checking failures if they rely on stack-allocated arrays for large, potentially variable data like `argv`.
+**Prevention:** Always perform explicit bounds checking when copying string arrays or variable-length data into fixed-size stack buffers, returning an error like `_E2BIG` (Argument list too long) if the buffer size limit is exceeded.

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -99,6 +99,8 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     size_t p = 0;
     while (i < argc) {
         const size_t arg_len = strlen(argv[i]) + 1;
+        if (p + arg_len > sizeof(argv_copy) - 1)
+            return _E2BIG;
         memcpy(&argv_copy[p], argv[i], arg_len);
         p += arg_len;
         i++;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** In `xX_main_Xx.h`, the loop that copies command line arguments into the `argv_copy` stack buffer lacked bounds checking. An excessively long argument list passed to this setup function could overwrite adjacent stack memory.
🎯 **Impact:** If exploited, an attacker or uncontrolled script passing heavily padded arguments could cause a stack buffer overflow, potentially leading to a crash or arbitrary code execution in the kernel startup context.
🔧 **Fix:** Added explicit bounds checking in the `while (i < argc)` loop. If adding the length of the current argument to `p` exceeds the capacity of `argv_copy`, it safely returns `_E2BIG` ("Argument list too long").
✅ **Verification:** A standalone C test (`test_overflow.c`) using mocked structures was created to confirm that argument arrays exceeding 4096 bytes correctly return `-7` (`_E2BIG`), while shorter inputs succeed. Pre-commit syntax checking via `gcc -fsyntax-only` confirmed no syntax errors were introduced.

---
*PR created automatically by Jules for task [14073488721706342352](https://jules.google.com/task/14073488721706342352) started by @emkey1*