### PR TITLE
⚡ Bolt: Hoist `strlen` calculation in `contains_mount_point`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Kernel Stack Limitations
 **Learning:** Allocating large buffers (e.g., 4096 bytes) directly on the kernel stack in `kernel/fs.c` (like inside `sys_read`) will cause kernel stack overflow. In this architecture, the kernel stack is small and bounded.
 **Action:** When optimizing away `malloc` calls for small operations in the kernel, limit stack-allocated buffers to small, safe sizes like 256 bytes and fall back to heap allocation for larger requests.
+
+## 2024-05-25 - Redundant string lengths in loop
+**Learning:** In VFS functions like `fs/generic.c`, calculating string lengths (e.g. `strlen(path)`) inside iteration loops (e.g. `list_for_each_entry`) degrades performance from O(N+M) to O(N*M) where N is loop iterations and M is path length.
+**Action:** Pre-calculate `strlen()` outside loops to prevent O(N) performance degradation during list traversals.

--- a/fs/generic.c
+++ b/fs/generic.c
@@ -22,8 +22,10 @@ struct mount *find_mount_and_trim_path(char *path) {
 
 bool contains_mount_point(const char *path) {
     struct mount *mount;
+    // Bolt: Hoist strlen(path) outside the loop to avoid O(N) performance
+    // degradation during list traversals where N is number of mounts.
+    int n = strlen(path);
     list_for_each_entry(&mounts, mount, mounts) {
-        int n = strlen(path);
         if (strncmp(path, mount->point, n) == 0 &&
                 (mount->point[n] == '\0' || mount->point[n] == '/'))
             return true;


### PR DESCRIPTION
💡 **What:** Hoisted the `strlen(path)` calculation outside the `list_for_each_entry` loop in `contains_mount_point` in `fs/generic.c`.
🎯 **Why:** `path` remains completely unchanged during the list traversal loop. Calculating its length in every single loop iteration needlessly burns CPU cycles and degrades time complexity.
📊 **Impact:** Reduces time complexity of `contains_mount_point` from O(N*M) to O(N+M) (N = number of mounts, M = length of path), providing a small but reliable speed boost to file system path resolution. 
🔬 **Measurement:** A standalone C benchmark (`tests/unit/test_generic_contains_mount_point.c`) successfully validated that the modified logic correctly matches existing behavior and ensures `strlen` is only called once.

---
*PR created automatically by Jules for task [13326796699114104749](https://jules.google.com/task/13326796699114104749) started by @emkey1*