### PR TITLE
🎨 Palette: Announce selection state on theme cells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+## 2026-03-13 - Table Cell Selection State Accessibility
+**Learning:** When using `UITableViewCellAccessoryCheckmark` to indicate selection, VoiceOver users will not be informed of the state change. `UIAccessibilityTraitSelected` must be manually toggled.
+**Action:** Always manually toggle `UIAccessibilityTraitSelected` alongside checkmark accessory types on table cells.

--- a/app/ThemesViewController.m
+++ b/app/ThemesViewController.m
@@ -172,7 +172,13 @@ enum {
     }
     
     cell.textLabel.text = theme.name;
-    cell.accessoryType = [theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    if ([theme.name isEqualToString:self->_theme.name] && (!self->_preferUserTheme || indexPath.section == UserSection)) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     cell.textLabel.enabled = ![theme.name isEqualToString:self->_theme.name] || indexPath.section != DefaultSection || !self->_preferUserTheme;
     cell.editingAccessoryType = UITableViewCellAccessoryDisclosureIndicator;
     


### PR DESCRIPTION
💡 **What:** Added `UIAccessibilityTraitSelected` to the currently selected theme cell in `ThemesViewController`.
🎯 **Why:** VoiceOver users were not being informed when a theme was selected because `UITableViewCellAccessoryCheckmark` is only a visual indicator. Adding the explicit trait ensures the selection state is correctly announced.
♿ **Accessibility:** VoiceOver now correctly announces "Selected" when focusing on the currently active theme in the list.

---
*PR created automatically by Jules for task [6240693057907974615](https://jules.google.com/task/6240693057907974615) started by @emkey1*