### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack buffer overflow in argv parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2024-05-24 - [Fix stack buffer overflow in argv parsing]
+**Vulnerability:** A critical stack buffer overflow vulnerability existed in `xX_main_Xx.h` during argument parsing (`argv_copy`). The while loop copied unbounded command-line arguments into a fixed 4096-byte stack array without bounds checking.
+**Learning:** Hardcoded stack buffer limits can be easily bypassed by large user inputs (e.g., passing numerous large command-line arguments), leading to stack corruption, crashes, and potentially arbitrary code execution.
+**Prevention:** Always validate the length of user inputs against the target buffer size before copying data. Use exact boundary checks (e.g., `if (p + arg_len > sizeof(argv_copy) - 1)`) and return appropriate error codes (e.g., `_E2BIG`) when limits are exceeded.

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -99,6 +99,9 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     size_t p = 0;
     while (i < argc) {
         const size_t arg_len = strlen(argv[i]) + 1;
+        // 🛡️ Sentinel: bounds check to prevent stack buffer overflow
+        if (p + arg_len > sizeof(argv_copy) - 1)
+            return _E2BIG;
         memcpy(&argv_copy[p], argv[i], arg_len);
         p += arg_len;
         i++;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `xX_main_Xx` initialization routine copied unbounded user-provided command-line arguments into a fixed 4096-byte stack array `argv_copy` without verifying boundaries. A malicious or long set of arguments could overflow the stack array, leading to memory corruption or arbitrary code execution.
🎯 Impact: Exploitation of this overflow could compromise the kernel's stack, causing crashes or allowing an attacker to execute arbitrary code during early process initialization.
🔧 Fix: Added a bounds check inside the while loop that copies the elements of `argv` to `argv_copy`. The check `if (p + arg_len > sizeof(argv_copy) - 1)` ensures that no buffer overflow can occur, returning `_E2BIG` securely when arguments exceed the stack buffer size. Also added a journal entry in `.jules/sentinel.md` documenting this finding.
✅ Verification: Tested via standalone script mimicking the `xX_main_Xx.h` parsing logic to ensure `_E2BIG` is correctly and reliably returned when arguments exceed the array bounds. Syntax validation on `main.c` also succeeded.

---
*PR created automatically by Jules for task [10292232193387125071](https://jules.google.com/task/10292232193387125071) started by @emkey1*