### PR TITLE
🎨 Palette: Add accessibility trait for selected list items

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2024-05-25 - UITableViewCellAccessoryCheckmark Accessibility
+**Learning:** In iOS `UITableView` implementations, modifying `UITableViewCellAccessoryCheckmark` does not automatically toggle the `UIAccessibilityTraitSelected` trait for VoiceOver users. On reused cells, failing to explicitly reset this trait can lead to incorrect VoiceOver announcements.
+**Action:** Always use bitwise operators (`|=` to set, `&= ~` to clear) to manually toggle `UIAccessibilityTraitSelected` alongside changes to `UITableViewCellAccessoryCheckmark` for cells.

--- a/app/AboutAppearanceViewController.m
+++ b/app/AboutAppearanceViewController.m
@@ -218,7 +218,13 @@ enum {
                     cell.textLabel.text = @"Dark";
                     break;
             }
-            cell.accessoryType = indexPath.row == UserPreferences.shared.colorScheme ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+            if (indexPath.row == UserPreferences.shared.colorScheme) {
+                cell.accessoryType = UITableViewCellAccessoryCheckmark;
+                cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+            } else {
+                cell.accessoryType = UITableViewCellAccessoryNone;
+                cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+            }
             break;
             
         case CursorSection:

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` explicitly to `UITableViewCell` instances that have `UITableViewCellAccessoryCheckmark`.
🎯 Why: While `UITableViewCellAccessoryCheckmark` provides a visual cue for selected items, it does not implicitly announce the selection state to VoiceOver users. This change ensures that screen readers correctly identify these items as "selected".
📸 Before/After: N/A - non-visual change.
♿ Accessibility: Improved VoiceOver experience for users selecting options from lists (e.g., Font selection, Color Scheme selection).

---
*PR created automatically by Jules for task [16738696669417287453](https://jules.google.com/task/16738696669417287453) started by @emkey1*