### PR TITLE
⚡ Bolt: Optimize VFS path resolution loop performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Kernel Stack Limitations
 **Learning:** Allocating large buffers (e.g., 4096 bytes) directly on the kernel stack in `kernel/fs.c` (like inside `sys_read`) will cause kernel stack overflow. In this architecture, the kernel stack is small and bounded.
 **Action:** When optimizing away `malloc` calls for small operations in the kernel, limit stack-allocated buffers to small, safe sizes like 256 bytes and fall back to heap allocation for larger requests.
+
+## 2026-03-15 - Optimize VFS string lengths
+**Learning:** Struct-cached lengths and hoisting loop-invariant string traversals prevent O(N) performance degradation during VFS operations.
+**Action:** Pre-calculate lengths outside loops or use struct-cached lengths (like `point_len` in `struct mount`) to avoid recalculating string lengths inside loops.

--- a/fs/generic.c
+++ b/fs/generic.c
@@ -22,8 +22,8 @@ struct mount *find_mount_and_trim_path(char *path) {
 
 bool contains_mount_point(const char *path) {
     struct mount *mount;
+    int n = strlen(path);
     list_for_each_entry(&mounts, mount, mounts) {
-        int n = strlen(path);
         if (strncmp(path, mount->point, n) == 0 &&
                 (mount->point[n] == '\0' || mount->point[n] == '/'))
             return true;

--- a/fs/mount.c
+++ b/fs/mount.c
@@ -44,7 +44,7 @@ struct mount *mount_find(char *path) {
     struct mount *mount = NULL;
     assert(!list_empty(&mounts)); // this would mean there's no root FS mounted
     list_for_each_entry(&mounts, mount, mounts) {
-        size_t n = strlen(mount->point);
+        size_t n = mount->point_len;
         if (strncmp(path, mount->point, n) == 0 && (path[n] == '/' || path[n] == '\0'))
             break;
     }
@@ -90,7 +90,7 @@ int do_mount(const struct fs_ops *fs, const char *source, const char *point, con
     // the list must stay in descending order of mount point length
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
-        if (strlen(mount->point) <= strlen(new_mount->point))
+        if (mount->point_len <= new_mount->point_len)
             break;
     }
     list_add_before(&mount->mounts, &new_mount->mounts);


### PR DESCRIPTION
💡 **What:** 
Replaced `strlen` calculations with cached struct lengths (`mount->point_len`) in `fs/mount.c` list traversals (`mount_find`, `do_mount`). Hoisted the loop-invariant `strlen(path)` calculation out of the `list_for_each_entry` loop in `contains_mount_point` (`fs/generic.c`).

🎯 **Why:** 
VFS operations frequently traverse lists of mount points. Recalculating string lengths for static path segments or cached mount points *inside* these loops causes O(N) performance degradation as the number of mount points grows.

📊 **Impact:** 
Reduces CPU cycles wasted on repeated `strlen` operations during fundamental path resolution logic across the filesystem boundary. This optimization prevents unnecessary scaling bottlenecks when multiple filesystems are mounted.

🔬 **Measurement:** 
Unit tests were written and executed (`tests/unit/test_perf.c`) to confirm the mocked loops complete without logical regressions, proving identical branch logic using pre-calculated sizes. Syntax validation was successfully verified using `gcc -fsyntax-only`.

---
*PR created automatically by Jules for task [3479671843767338218](https://jules.google.com/task/3479671843767338218) started by @emkey1*