### PR TITLE
🎨 Palette: Fix VoiceOver and UI state on recycled cells

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2024-05-25 - Recycled UITableViewCell State Management
+**Learning:** When using reused `UITableViewCell` instances in iOS (e.g., via `dequeueReusableCellWithIdentifier:`), failing to explicitly reset UI state (like `accessoryType`) and accessibility traits (like `UIAccessibilityTraitSelected`) on unselected cells causes them to retain the state of the previously displayed cell. This leads to confusing visual bugs and incorrect VoiceOver announcements.
+**Action:** Always explicitly reset `accessoryType` to `UITableViewCellAccessoryNone` and clear the `UIAccessibilityTraitSelected` trait (`cell.accessibilityTraits &= ~UIAccessibilityTraitSelected`) for unselected cells in `cellForRowAtIndexPath:`.

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 **What:** Added an `else` branch in `FontPickerViewController.m`'s `cellForRowAtIndexPath:` to explicitly reset the `accessoryType` to `UITableViewCellAccessoryNone` and clear the `UIAccessibilityTraitSelected` trait when configuring a cell for an unselected font.

🎯 **Why:** `UITableViewCell` instances are recycled. If a previously selected cell (with a checkmark and the "Selected" trait) is recycled to display an unselected font, it retains the checkmark and the VoiceOver announcement unless explicitly reset. This led to confusing visual bugs and accessibility errors for VoiceOver users when scrolling through the font picker.

📸 **Before/After:** No major visual layout changes, but checkmarks now only appear on the actually selected font, even after aggressive scrolling.

♿ **Accessibility:** VoiceOver will now accurately announce only the currently active font as "Selected". It will no longer erroneously announce unselected fonts as "Selected" when they happen to reuse a cell that was previously selected. The learning has been logged to `.jules/palette.md`.

---
*PR created automatically by Jules for task [1973038387991048262](https://jules.google.com/task/1973038387991048262) started by @emkey1*