### PR TITLE
⚡ Bolt: Optimize string concatenation in fakefs_readdir

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Kernel Stack Limitations
 **Learning:** Allocating large buffers (e.g., 4096 bytes) directly on the kernel stack in `kernel/fs.c` (like inside `sys_read`) will cause kernel stack overflow. In this architecture, the kernel stack is small and bounded.
 **Action:** When optimizing away `malloc` calls for small operations in the kernel, limit stack-allocated buffers to small, safe sizes like 256 bytes and fall back to heap allocation for larger requests.
+## 2024-05-24 - [Optimize string concatenation in fakefs_readdir]
+**Learning:** Using `strcat` in performance-critical VFS loops (like `fakefs_readdir` in `fs/fake.c`) introduces O(N) overhead as it repeatedly scans for the null terminator.
+**Action:** Replace `strcat` calls with direct array assignment (`path[len] = '/'`) and `memcpy` using pre-calculated string lengths.

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -364,11 +364,13 @@ retry:
             *strrchr(entry_path, '/') = '\0';
         }
     } else if (strcmp(entry->name, ".") != 0) {
+        size_t path_len = strlen(entry_path);
+        size_t name_len = strlen(entry->name);
         // god I don't know what to do if this would overflow
-        if (strlen(entry_path) + 1 + strlen(entry->name) >= sizeof(entry_path))
+        if (path_len + 1 + name_len >= sizeof(entry_path))
             goto retry;
-        strcat(entry_path, "/");
-        strcat(entry_path, entry->name);
+        entry_path[path_len] = '/';
+        memcpy(entry_path + path_len + 1, entry->name, name_len + 1);
     }
 
     struct fakefs_db *fs = &fd->mount->fakefs;


### PR DESCRIPTION
### 💡 What
Replaced consecutive `strcat()` calls in `fakefs_readdir` (within `fs/fake.c`) with pre-calculated lengths, direct array assignment, and `memcpy()`.

### 🎯 Why
In performance-critical VFS loops, `strcat` introduces O(N) overhead as it repeatedly scans the destination string to find the null terminator before appending. When appending a trailing slash and the next directory entry name, recalculating `strlen` via `strcat` adds up in loop heavy code. By reusing the already computed string lengths (`path_len` and `name_len`), we can append with an O(1) memory copy and array assignment. 

### 📊 Impact
Eliminates redundant string traversals during directory reads (`readdir`). This removes O(N) traversal overhead in the inner condition path and improves latency during complex directory indexing or metadata loading sequences where `fakefs_readdir` is hit repetitively. 

### 🔬 Measurement
Verified the bounds checking logic matches original limits and that the code compiles cleanly via `gcc -fsyntax-only fs/fake.c -I. -D_GNU_SOURCE`. Verified using static analysis that length computations properly ensure no buffer overflows occur.

---
*PR created automatically by Jules for task [16570778255282399154](https://jules.google.com/task/16570778255282399154) started by @emkey1*