### PR TITLE
🎨 Palette: Fix UITableViewCell accessibility and reuse states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-24 - Accessibility Availability Checks
 **Learning:** Accessibility properties like `accessibilityLabel` are often available in earlier iOS versions than visual features like SF Symbols. Wrapping them in `@available` checks for visual features unnecessarily restricts accessibility on older OS versions.
 **Action:** Separate accessibility configuration from version-specific visual setup to ensure broader support.
+
+## 2026-03-16 - UITableViewCell Accessibility and Reuse
+**Learning:** When reusing `UITableViewCell` instances, it is critical to explicitly reset accessibility traits (like `UIAccessibilityTraitSelected`) and visual states (like `accessoryType`) for unselected cells, otherwise VoiceOver and the visual UI will announce/show incorrect states on recycled cells.
+**Action:** Always provide an `else` block to clear selection state (`accessoryType = UITableViewCellAccessoryNone` and `traits &= ~UIAccessibilityTraitSelected`) when configuring recycled table view cells.

--- a/app/FontPickerViewController.m
+++ b/app/FontPickerViewController.m
@@ -39,8 +39,13 @@
     cell.textLabel.font = [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:font];
     cell.textLabel.adjustsFontForContentSizeCategory = YES;
     cell.textLabel.text = family;
-    if ([family isEqualToString:UserPreferences.shared.fontFamily])
+    if ([family isEqualToString:UserPreferences.shared.fontFamily]) {
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 **What**: Added an `else` block to explicitly clear the selection state and `UIAccessibilityTraitSelected` for unselected cells during `tableView:cellForRowAtIndexPath:` configuration in `FontPickerViewController.m`.
🎯 **Why**: When users scroll through long lists, `UITableViewCell` instances are recycled. If a previously selected cell is reused for an unselected item, VoiceOver incorrectly announces it as "selected," and visually it may retain incorrect states if not explicitly cleared.
📸 **Before/After**: Visually, previously-selected recycled cells no longer retain their states incorrectly.
♿ **Accessibility**: VoiceOver accurately reflects the selection state of cells after scrolling instead of getting "stuck" announcing recycled unselected cells as "selected".

---
*PR created automatically by Jules for task [18416621197447556421](https://jules.google.com/task/18416621197447556421) started by @emkey1*