### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in boot_command_line assignment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,11 @@
 **Vulnerability:** `user_read_string` contained a logic error where the return value of `__user_read_task` was discarded using the comma operator with `false` (`func(), false`), causing the error check to always fail (i.e., assume success).
 **Learning:** The comma operator can be dangerous when used in conditional statements, especially if it looks like a function argument or a typo. It can silently suppress error checks.
 **Prevention:** Always verify argument counts and parenthesis matching. Use static analysis tools that might catch "statement has no effect" or "comma operator used in if condition".
+
+## 2024-05-23 - Buffer Overflow in boot_command_line assignment
+**Vulnerability:**
+The `boot_command_line` buffer could be overflowed in `app/LinuxInterop.c` via unbounded `strcpy` when executing `actuate_kernel(cmdline)`, and in `linux/main.c` via unbounded `strcat` when parsing arguments.
+**Learning:**
+Always use bounding functions (`strncpy` or `strncat`) when interacting with `boot_command_line` buffer or other static arrays to prevent buffer overflows that could lead to malicious code execution or kernel crash.
+**Prevention:**
+Enforce strict bounds checking. `strncpy(dest, src, sizeof(dest) - 1); dest[sizeof(dest) - 1] = '\0';` and `strncat(dest, src, sizeof(dest) - strlen(dest) - 1);` should be used instead of their unbounded counterparts.

--- a/app/LinuxInterop.c
+++ b/app/LinuxInterop.c
@@ -28,7 +28,8 @@
 extern void run_kernel(void);
 
 void actuate_kernel(const char *cmdline) {
-    strcpy(boot_command_line, cmdline);
+    strncpy(boot_command_line, cmdline, sizeof(boot_command_line) - 1);
+    boot_command_line[sizeof(boot_command_line) - 1] = '\0';
     run_kernel();
 }
 

--- a/linux/main.c
+++ b/linux/main.c
@@ -10,8 +10,8 @@ int main(int argc, const char *argv[])
 	int i;
 	for (i = 1; i < argc; i++) {
 		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+			strncat(boot_command_line, " ", sizeof(boot_command_line) - strlen(boot_command_line) - 1);
+		strncat(boot_command_line, argv[i], sizeof(boot_command_line) - strlen(boot_command_line) - 1);
 	}
 	run_kernel();
 	for (;;) host_pause();


### PR DESCRIPTION
🎯 **What:** Fixed two distinct buffer overflow vulnerabilities where user-provided arguments were copied into the static `boot_command_line` buffer using unbounded string operations (`strcpy` and `strcat`).

⚠️ **Risk:** Exploitation could allow attackers (or malicious shell scripts) to overflow `boot_command_line` leading to arbitrary code execution within the app or severe kernel panics / denial-of-service, given this data acts as a direct input to the core kernel setup logic.

🛡️ **Solution:**
- In `app/LinuxInterop.c`'s `actuate_kernel` function, replaced `strcpy` with `strncpy`, capping the copy at `sizeof(boot_command_line) - 1`, and explicitly setting the null terminator to guarantee memory safety.
- In `linux/main.c`'s `main` argument parser, replaced sequential `strcat` calls with `strncat`, correctly updating the bounds calculation (`sizeof(...) - strlen(...) - 1`) based on the dynamically growing buffer size.
- Documented these findings and learnings inside `.jules/sentinel.md` as per persona requirements.

---
*PR created automatically by Jules for task [12667236481748319898](https://jules.google.com/task/12667236481748319898) started by @emkey1*