### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix thread name data race and unprotected write

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A local variable `char new_argv_buf[ARGV_MAX];` allocated 128KB on the kernel stack in `shebang_exec` (`kernel/exec.c`). Given strict kernel stack limits, an attacker could trigger a stack overflow by executing a shebang script, leading to a Denial of Service (DoS) or potential arbitrary code execution within the kernel environment.
 **Learning:** Massive constants like `ARGV_MAX` (128KB) should never be used to allocate arrays on the stack due to tight stack limitations, even for short-lived operations.
 **Prevention:** Large buffers must be dynamically allocated on the heap using `malloc()` with proper `NULL` checks, and they must be freed on all execution paths to prevent memory leaks while avoiding stack overflow DoS vulnerabilities.
+
+## 2026-03-17 - Thread Name Data Race and Unprotected Write
+**Vulnerability:** In `kernel/misc.c`, the `sys_prctl` syscall updated `current->comm` (the thread name) via `strcpy` without holding the necessary lock (`current->general_lock`), which could lead to data races with concurrent readers.
+**Learning:** Thread name updates must always be protected by the `general_lock` and should ideally use bounded copy functions like `strncpy` for defense-in-depth, even if the input string is known to be null-terminated.
+**Prevention:** Ensure that access to `current->comm` is properly synchronized across all syscalls and kernel paths. Use `strncpy` to prevent accidental buffer overflows if the target buffer size ever changes.

--- a/kernel/misc.c
+++ b/kernel/misc.c
@@ -15,7 +15,9 @@ int_t sys_prctl(dword_t option, uint_t arg2, uint_t UNUSED(arg3), uint_t UNUSED(
                 return _EFAULT;
             name[sizeof(name) - 1] = '\0';
             STRACE("prctl(PRCTL_SET_NAME, \"%s\")", name);
-            strcpy(current->comm, name);
+            lock(&current->general_lock, 0);
+            strncpy(current->comm, name, sizeof(current->comm));
+            unlock(&current->general_lock);
             return 0;
         }
         default:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `sys_prctl` updated `current->comm` using `strcpy` without holding `current->general_lock`.
🎯 Impact: This could lead to data races when reading or writing thread names concurrently (e.g., via `/proc/[pid]/comm` or context switches), potentially causing memory corruption. Also used `strcpy` which is less safe than bounded copying.
🔧 Fix: Wrapped the `current->comm` update in `sys_prctl` with `lock(&current->general_lock, 0)` and `unlock(&current->general_lock)`. Changed `strcpy` to `strncpy` for defense-in-depth against potential buffer overflows if the target buffer's size ever changes.
✅ Verification: `gcc -fsyntax-only kernel/misc.c -I. -D_GNU_SOURCE` and `make` passes syntax validation. e2e tests were executed.

---
*PR created automatically by Jules for task [707214448631217128](https://jules.google.com/task/707214448631217128) started by @emkey1*