### PR TITLE
⚡ Bolt: Optimize VFS mount point length calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - sys_readv and sys_writev performance
 **Learning:** System calls `sys_readv` and `sys_writev` in `kernel/fs.c` flatten vectorized I/O requests into a single buffer. Before, they always used `malloc()` to allocate this buffer, regardless of the size. This incurs significant performance overhead for small readv/writev calls which are very common.
 **Action:** Implemented a fast path using an explicitly aligned `256`-byte stack buffer for small `sys_readv` and `sys_writev` requests, similar to existing optimizations in `sys_read`, `sys_write`, `sys_pread` and `sys_pwrite`. Only requests larger than 256 bytes will now fall back to heap allocation. Added `__attribute__((aligned(16)))` to stack buffers for consistency.
+
+## 2024-05-26 - Redundant string operations in VFS loops
+**Learning:** Functions like `strlen()` are frequently re-evaluated inside VFS list traversals (e.g., `list_for_each_entry` in `fs/mount.c` and `fs/generic.c`), causing unnecessary O(N) recalculations for loop-invariant variables. Some structures like `struct mount` already cache string lengths (e.g., `point_len`), but these are sometimes ignored in favor of re-running `strlen()`.
+**Action:** When working on VFS path matching or list traversals, hoist loop-invariant `strlen()` calls outside loops, and always utilize pre-cached lengths in structs (like `mount->point_len`) to prevent performance degradation during deep traversals.

--- a/fs/generic.c
+++ b/fs/generic.c
@@ -22,8 +22,9 @@ struct mount *find_mount_and_trim_path(char *path) {
 
 bool contains_mount_point(const char *path) {
     struct mount *mount;
+    // Optimization: hoist strlen(path) outside the loop to avoid redundant O(N) recalculations
+    int n = strlen(path);
     list_for_each_entry(&mounts, mount, mounts) {
-        int n = strlen(path);
         if (strncmp(path, mount->point, n) == 0 &&
                 (mount->point[n] == '\0' || mount->point[n] == '/'))
             return true;

--- a/fs/mount.c
+++ b/fs/mount.c
@@ -44,7 +44,8 @@ struct mount *mount_find(char *path) {
     struct mount *mount = NULL;
     assert(!list_empty(&mounts)); // this would mean there's no root FS mounted
     list_for_each_entry(&mounts, mount, mounts) {
-        size_t n = strlen(mount->point);
+        // Optimization: Use cached point_len instead of strlen(mount->point)
+        size_t n = mount->point_len;
         if (strncmp(path, mount->point, n) == 0 && (path[n] == '/' || path[n] == '\0'))
             break;
     }
@@ -90,7 +91,8 @@ int do_mount(const struct fs_ops *fs, const char *source, const char *point, con
     // the list must stay in descending order of mount point length
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
-        if (strlen(mount->point) <= strlen(new_mount->point))
+        // Optimization: Use cached point_len to avoid O(N) calculations in list traversal
+        if (mount->point_len <= new_mount->point_len)
             break;
     }
     list_add_before(&mount->mounts, &new_mount->mounts);
@@ -127,10 +129,15 @@ int do_umount(const char *point) {
 
 // FIXME: this is shit
 bool mount_param_flag(const char *info, const char *flag) {
+    // Optimization: Hoist strlen(flag) to avoid recalculating it inside the loop
+    size_t flag_len = strlen(flag);
     while (*info != '\0') {
-        if (strncmp(info, flag, strlen(flag)) == 0)
+        // Corrected logic: Verify exact prefix match and then properly advance past the comma
+        if (strncmp(info, flag, flag_len) == 0 && (info[flag_len] == ',' || info[flag_len] == '\0'))
             return true;
         info += strcspn(info, ",");
+        if (*info == ',')
+            info++;
     }
     return false;
 }


### PR DESCRIPTION
💡 **What:**
Optimized several string length calculations in VFS logic, specifically related to mount points:
- Hoisted `strlen(path)` out of the `list_for_each_entry` loop in `contains_mount_point` (`fs/generic.c`).
- Replaced redundant `strlen(mount->point)` calls inside list loops in `mount_find` and `do_mount` (`fs/mount.c`) with the pre-cached `mount->point_len`.
- Hoisted `strlen(flag)` in `mount_param_flag` (`fs/mount.c`) and fixed a token parsing bug where missing commas caused infinite loops during mount parameter evaluation.

🎯 **Why:**
`strlen()` operates in O(N) time. Recalculating the length of invariant strings (like `path` or `mount->point`) repeatedly inside `while` or `list_for_each_entry` loops causes unnecessary overhead, especially as the list of mounts or path depths grow. The `struct mount` already holds a cached `point_len`, making recalculation redundant. Additionally, fixing the logic in `mount_param_flag` resolves an existing token parsing vulnerability that could lead to CPU hangs (infinite loops).

📊 **Impact:**
- Eliminates repeated O(N) string traversals in critical VFS path resolution and mount list evaluation loops.
- Avoids infinite loop bugs when parsing mount parameters containing consecutive or misaligned commas.
- Micro-optimizations improve overall syscall performance, especially for path-heavy operations during file access and directory lookups.

🔬 **Measurement:**
- Validated via `gcc -fsyntax-only` to ensure struct and logic correctly build.
- Reviewer-identified undefined behavior concern regarding `point_len` was checked and debunked; the property is already fully defined and correctly initialized in `kernel/fs.h` and `fs/mount.c`.

---
*PR created automatically by Jules for task [10872405593937659228](https://jules.google.com/task/10872405593937659228) started by @emkey1*