### PR TITLE
🎨 Palette: Add proper accessibility traits to AltIconCell

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-25 - UITableViewCell Selection Accessibility and Reuse
 **Learning:** When managing state for reused `UITableViewCell` instances in iOS, relying only on `accessoryType` for visual state is insufficient for screen readers, and failing to clear state on unselected cells causes UI bugs when cells are recycled. VoiceOver users may not be aware of selection states indicated by checkmarks if traits are not updated.
 **Action:** Always explicitly reset `accessoryType` to `UITableViewCellAccessoryNone` and clear the `UIAccessibilityTraitSelected` trait (`cell.accessibilityTraits &= ~UIAccessibilityTraitSelected`) for unselected cells, while setting the selected trait when `UITableViewCellAccessoryCheckmark` is used.
+
+## 2024-05-26 - Destructive Updates to accessibilityTraits
+**Learning:** Overwriting `accessibilityTraits` using the assignment operator (`=`) when toggling states (e.g., `selected ? UIAccessibilityTraitSelected : 0`) deletes all inherent traits, such as `UIAccessibilityTraitButton`, causing VoiceOver to no longer announce the control type correctly.
+**Action:** Always use bitwise OR (`|=`) to add traits and bitwise AND NOT (`&= ~`) to remove traits to preserve existing state.

--- a/app/AltIconViewController.m
+++ b/app/AltIconViewController.m
@@ -131,6 +131,7 @@
     self.authorButton.titleLabel.adjustsFontForContentSizeCategory = YES;
 
     self.isAccessibilityElement = YES;
+    self.accessibilityTraits |= UIAccessibilityTraitButton;
     self.accessibilityCustomActions = @[[[UIAccessibilityCustomAction alloc] initWithName:@"Open link" target:self selector:@selector(openSource:)]];
 }
 
@@ -148,7 +149,11 @@
 - (void)setSelected:(BOOL)selected {
     [super setSelected:selected];
     self.checkboxImageView.hidden = !selected;
-    self.accessibilityTraits = selected ? UIAccessibilityTraitSelected : 0;
+    if (selected) {
+        self.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        self.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 @end


### PR DESCRIPTION
💡 **What:** Add proper initial accessibility trait (`UIAccessibilityTraitButton`) to the `AltIconCell` in `AltIconViewController`, and prevent `setSelected:` from completely overwriting all existing accessibility traits when toggling selection.
🎯 **Why:** Previously, VoiceOver users would lose context because the button trait would be missing, and toggling it overwrote the entire trait map.
♿ **Accessibility:** Fixes a VoiceOver bug where elements would not be consistently announced as buttons or indicate their selected state properly.

---
*PR created automatically by Jules for task [763232309649403811](https://jules.google.com/task/763232309649403811) started by @emkey1*