### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in get_filesystems

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** In `kernel/misc.c`, the `sys_prctl` syscall updated `current->comm` (the thread name) via `strcpy` without holding the necessary lock (`current->general_lock`), which could lead to data races with concurrent readers.
 **Learning:** Thread name updates must always be protected by the `general_lock` and should ideally use bounded copy functions like `strncpy` for defense-in-depth, even if the input string is known to be null-terminated.
 **Prevention:** Ensure that access to `current->comm` is properly synchronized across all syscalls and kernel paths. Use `strncpy` to prevent accidental buffer overflows if the target buffer size ever changes.
+
+## 2026-03-24 - Buffer Overflow in get_filesystems
+**Vulnerability:** The `get_filesystems` function in `fs/mount.c` used a fixed-size buffer (`calloc(MAX_FILESYSTEMS * 50)`) and consecutive `strcat` calls. If the names of registered filesystems were large enough, this would result in a heap buffer overflow.
+**Learning:** Fixed-size buffers with string concatenations in a loop are inherently prone to overflows, especially if the loop iterations or string lengths can grow over time. Even if seemingly "reasonable", they are fragile and create technical debt.
+**Prevention:** Use a two-pass approach for dynamic string accumulation: first, iterate to calculate the exact total length required; second, allocate the exact memory (`malloc` with a `NULL` check) and populate it (e.g., using pointer advancement and `memcpy`). This eliminates `strcat` entirely and ensures memory safety without arbitrary limitations.

--- a/fs/mount.c
+++ b/fs/mount.c
@@ -24,16 +24,33 @@ void fs_register(const struct fs_ops *fs) {
 }
 
 char * get_filesystems(void) {
-    char *fs_list = calloc(MAX_FILESYSTEMS * 50, sizeof(char)); // Reasonable assumption?
     unsigned int i;
+    size_t total_len = 0;
 
+    // Pass 1: Calculate the exact length required
     for (i = 0; i < MAX_FILESYSTEMS; i++) {
         if (filesystems[i] != NULL) {
-            fs_list = strcat(fs_list, "nodev    ");
-            fs_list = strcat(fs_list, filesystems[i]->name);
-            fs_list = strcat(fs_list, "\n");
+            total_len += strlen("nodev    ") + strlen(filesystems[i]->name) + 1; // +1 for newline
         }
     }
+
+    // Pass 2: Allocate and populate the buffer
+    char *fs_list = malloc(total_len + 1); // +1 for null terminator
+    if (fs_list == NULL)
+        return NULL;
+
+    char *ptr = fs_list;
+    for (i = 0; i < MAX_FILESYSTEMS; i++) {
+        if (filesystems[i] != NULL) {
+            size_t name_len = strlen(filesystems[i]->name);
+            memcpy(ptr, "nodev    ", 9);
+            ptr += 9;
+            memcpy(ptr, filesystems[i]->name, name_len);
+            ptr += name_len;
+            *ptr++ = '\n';
+        }
+    }
+    *ptr = '\0';
 
     return fs_list;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `get_filesystems` function in `fs/mount.c` (used by `/proc/filesystems`) used a fixed-size `calloc` buffer and consecutive `strcat` calls. If filesystem names are long, this overflows the heap buffer.
🎯 Impact: Heap buffer overflow which could lead to DoS or arbitrary code execution within the kernel environment.
🔧 Fix: Replaced the fixed-size buffer and `strcat` loop with a two-pass approach: first computing the exact string length needed, then allocating the precise amount of memory via `malloc` and populating it with `memcpy`. 
✅ Verification: Ran `gcc -fsyntax-only` to ensure compilation is intact and updated the `.jules/sentinel.md` journal. Mandatory verification step for `./tests/e2e/e2e.bash` was also run.

---
*PR created automatically by Jules for task [2588537592637022162](https://jules.google.com/task/2588537592637022162) started by @emkey1*