### PR TITLE
⚡ Bolt: Optimize string concatenation in fakefs_readdir

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-05-26 - Redundant string operations in VFS loops
 **Learning:** Functions like `strlen()` are frequently re-evaluated inside VFS list traversals (e.g., `list_for_each_entry` in `fs/mount.c` and `fs/generic.c`), causing unnecessary O(N) recalculations for loop-invariant variables. Some structures like `struct mount` already cache string lengths (e.g., `point_len`), but these are sometimes ignored in favor of re-running `strlen()`.
 **Action:** When working on VFS path matching or list traversals, hoist loop-invariant `strlen()` calls outside loops, and always utilize pre-cached lengths in structs (like `mount->point_len`) to prevent performance degradation during deep traversals.
+
+## 2026-03-18 - Optimize string concatenation in fakefs_readdir
+**Learning:** In performance-critical VFS loops like fakefs_readdir, using strcat causes O(N) recalculations of string length. Since the lengths of the directory path and entry name are already known or computed for bounds checking, they can be reused to perform direct array assignment and memcpy.
+**Action:** Replace O(N) strcat calls with direct array assignment (e.g., path[len] = '/') and memcpy() using pre-calculated string lengths to prevent performance degradation during directory traversal.

--- a/fs/fake.c
+++ b/fs/fake.c
@@ -364,11 +364,13 @@ retry:
             *strrchr(entry_path, '/') = '\0';
         }
     } else if (strcmp(entry->name, ".") != 0) {
+        size_t path_len = strlen(entry_path);
+        size_t name_len = strlen(entry->name);
         // god I don't know what to do if this would overflow
-        if (strlen(entry_path) + 1 + strlen(entry->name) >= sizeof(entry_path))
+        if (path_len + 1 + name_len >= sizeof(entry_path))
             goto retry;
-        strcat(entry_path, "/");
-        strcat(entry_path, entry->name);
+        entry_path[path_len] = '/';
+        memcpy(entry_path + path_len + 1, entry->name, name_len + 1);
     }
 
     struct fakefs_db *fs = &fd->mount->fakefs;


### PR DESCRIPTION
### 💡 What:
Replaced `strcat` calls in the `fakefs_readdir` function with direct array assignment and `memcpy`, using string lengths that were already calculated for bounds checking.

### 🎯 Why:
Inside performance-critical VFS loops like directory reading (`readdir`), `strcat` forces a re-traversal of the string to find the null terminator, creating O(N) recalculations of string length. Because `fakefs_readdir` already computes both `strlen(entry_path)` and `strlen(entry->name)` to check buffer capacities, we can reuse these values to perform operations in O(1) relative to the existing path length.

### 📊 Impact:
Slight reduction in CPU cycles spent traversing strings inside the VFS directory read loop. This speeds up directory traversals in environments heavily utilizing `fakefs`.

### 🔬 Measurement:
A standalone performance test (which was temporarily constructed and run) showed equivalent structural output but inherently avoids the implicit `strlen` iterations caused by `strcat`. Validated structurally through C syntax checks (`gcc -fsyntax-only`).

---
*PR created automatically by Jules for task [3269975101290123981](https://jules.google.com/task/3269975101290123981) started by @emkey1*