### PR TITLE
Refactor inode existence check into fake-db.c

### DIFF
--- a/app/FileProvider/FileProviderExtension.m
+++ b/app/FileProvider/FileProviderExtension.m
@@ -413,12 +413,7 @@
         if (inode == 0)
             continue;
 
-        // TODO: make this a function in fake-db.c
-        db_begin(&_mount.db);
-        sqlite3_bind_int64(_mount.db.stmt.inode_read_stat, 1, inode);
-        BOOL exists = db_exec(&_mount.db, _mount.db.stmt.inode_read_stat);
-        db_reset(&_mount.db, _mount.db.stmt.inode_read_stat);
-        db_rollback(&_mount.db);
+        BOOL exists = inode_exists(&_mount.db, inode);
 
         if (!exists) {
             NSLog(@"removing dead inode %llu", inode);

--- a/fs/fake-db.c
+++ b/fs/fake-db.c
@@ -97,6 +97,15 @@ inode_t path_create(struct fakefs_db *fs, const char *path, struct ish_stat *sta
     return inode;
 }
 
+bool inode_exists(struct fakefs_db *fs, inode_t inode) {
+    db_begin(fs);
+    sqlite3_bind_int64(fs->stmt.inode_read_stat, 1, inode);
+    bool exists = db_exec(fs, fs->stmt.inode_read_stat);
+    db_reset(fs, fs->stmt.inode_read_stat);
+    db_rollback(fs);
+    return exists;
+}
+
 void inode_read_stat(struct fakefs_db *fs, inode_t inode, struct ish_stat *stat) {
     // select stat from stats where inode = ?
     sqlite3_bind_int64(fs->stmt.inode_read_stat, 1, inode);

--- a/fs/fake-db.h
+++ b/fs/fake-db.h
@@ -51,6 +51,7 @@ inode_t path_get_inode(struct fakefs_db *fs, const char *path);
 bool path_read_stat(struct fakefs_db *fs, const char *path, struct ish_stat *stat, uint64_t *inode);
 inode_t path_create(struct fakefs_db *fs, const char *path, struct ish_stat *stat);
 
+bool inode_exists(struct fakefs_db *fs, inode_t inode);
 void inode_read_stat(struct fakefs_db *fs, inode_t inode, struct ish_stat *stat);
 void inode_write_stat(struct fakefs_db *fs, inode_t inode, struct ish_stat *stat);
 


### PR DESCRIPTION
Refactor inode existence check into fake-db.c

Resolves an inline `TODO: make this a function in fake-db.c` in `app/FileProvider/FileProviderExtension.m` by moving the db query logic (`db_begin`, `sqlite3_bind_int64`, `db_exec`, `db_reset`, `db_rollback`) into a dedicated reusable C function `inode_exists` in `fs/fake-db.c`.

---
*PR created automatically by Jules for task [358725292868043133](https://jules.google.com/task/358725292868043133) started by @emkey1*