### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in command line argument copy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `get_filesystems` function in `fs/mount.c` used a fixed-size buffer (`calloc(MAX_FILESYSTEMS * 50)`) and consecutive `strcat` calls. If the names of registered filesystems were large enough, this would result in a heap buffer overflow.
 **Learning:** Fixed-size buffers with string concatenations in a loop are inherently prone to overflows, especially if the loop iterations or string lengths can grow over time. Even if seemingly "reasonable", they are fragile and create technical debt.
 **Prevention:** Use a two-pass approach for dynamic string accumulation: first, iterate to calculate the exact total length required; second, allocate the exact memory (`malloc` with a `NULL` check) and populate it (e.g., using pointer advancement and `memcpy`). This eliminates `strcat` entirely and ensures memory safety without arbitrary limitations.
+
+## 2026-03-24 - Buffer Overflow in Command Line Arguments Copy
+**Vulnerability:** In `xX_main_Xx.h`, the array `argv_copy` was statically sized at 4096 bytes. The arguments loop used `memcpy` to copy user-supplied inputs from `argv` directly into `argv_copy` based strictly on `strlen(argv[i])` without ensuring the total size remained within 4096 bytes. This allowed a stack buffer overflow by passing large command-line arguments.
+**Learning:** Hardcoded stack buffer limits with unchecked string accumulations are a critical vulnerability vector, especially for command-line arguments which are easily controlled by external actors.
+**Prevention:** Always implement explicit bounds checking before performing string copies or concatenations into stack-allocated buffers. Return appropriate errors (e.g., `_E2BIG`) if the boundary is exceeded.

--- a/xX_main_Xx.h
+++ b/xX_main_Xx.h
@@ -99,10 +99,14 @@ static inline int xX_main_Xx(int argc, char *const argv[], const char *envp) {
     size_t p = 0;
     while (i < argc) {
         const size_t arg_len = strlen(argv[i]) + 1;
+        if (p + arg_len > sizeof(argv_copy))
+            return _E2BIG;
         memcpy(&argv_copy[p], argv[i], arg_len);
         p += arg_len;
         i++;
     }
+    if (p >= sizeof(argv_copy))
+        return _E2BIG;
     argv_copy[p] = '\0';
     if (argv[optind] == NULL)
 	    return _ENOENT;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Statically sized stack buffer `argv_copy` in `xX_main_Xx.h` allowed a buffer overflow via unchecked string copies from user-supplied command line arguments.
🎯 Impact: An attacker or rogue script could trigger a stack buffer overflow, leading to memory corruption or potentially arbitrary code execution at initialization.
🔧 Fix: Implemented an explicit boundary check using `sizeof(argv_copy)`. Returns `_E2BIG` if the arguments list is too long.
✅ Verification: Ran `gcc -fsyntax-only` on an isolated test context mapping to `main.c` includes. Verified via `tests/e2e/e2e.bash` that syntax remains functional under normal usage limits.

---
*PR created automatically by Jules for task [15598069619493806998](https://jules.google.com/task/15598069619493806998) started by @emkey1*