### PR TITLE
🎨 Palette: Add accessibility hints to terminal bar buttons

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -115,11 +115,17 @@
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
     }
     self.infoButton.accessibilityLabel = @"Settings";
+    self.infoButton.accessibilityHint = @"Opens the application settings.";
     self.pasteButton.accessibilityLabel = @"Paste";
+    self.pasteButton.accessibilityHint = @"Pastes text from the clipboard.";
     self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
+    self.hideKeyboardButton.accessibilityHint = @"Dismisses the on-screen keyboard.";
     self.tabKey.accessibilityLabel = @"Tab";
+    self.tabKey.accessibilityHint = @"Sends a tab character.";
     self.controlKey.accessibilityLabel = @"Control";
+    self.controlKey.accessibilityHint = @"Toggles the control key modifier.";
     self.escapeKey.accessibilityLabel = @"Escape";
+    self.escapeKey.accessibilityHint = @"Sends an escape character.";
     
     [UserPreferences.shared observe:@[@"hideStatusBar"] options:0 owner:self usingBlock:^(typeof(self) self) {
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
💡 **What**: Added `accessibilityHint` strings to the icon-only action buttons in the terminal view's top bar (e.g., Settings, Paste, Hide Keyboard, Tab, Control, Escape).
🎯 **Why**: Screen reader (VoiceOver) users rely on `accessibilityHint` to understand the result of interacting with an element. Without it, icon-only buttons with just labels might leave the user guessing what action will be performed upon activation.
📸 **Before/After**: No visual change; this is a pure accessibility (VoiceOver) enhancement.
♿ **Accessibility**: Enhanced screen reader support by providing explicit contextual descriptions for button interactions, directly improving the micro-UX for visually impaired users.

---
*PR created automatically by Jules for task [1392816984617916619](https://jules.google.com/task/1392816984617916619) started by @emkey1*