### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace unsafe strcpy calls with strncpy in fs/tmp.c

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,7 @@
 **Vulnerability:** `fs/real.c` used a 20-byte buffer for formatting `/proc/self/fd/%d`, but the path prefix is 14 bytes and a 32-bit signed int can be 11 bytes, requiring at least 26 bytes. This allows a stack buffer overflow for very large file descriptors.
 **Learning:** Hardcoded buffer sizes for path formatting often fail to account for the maximum string length of integers.
 **Prevention:** Always allocate at least 32 bytes for paths containing PIDs or FDs, and consider using `snprintf` to avoid overflow entirely.
+## $(date +%Y-%m-%d) - Replace unsafe strcpy calls with strncpy in fs/tmp.c
+**Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[MAX_NAME + 1]`) in `fs/tmp.c`.
+**Learning:** Legacy VFS and temporary filesystem code often lacks explicit bounds checking, relying on higher-level path validation. This creates defense-in-depth vulnerabilities if `MAX_NAME` bounds are ever exceeded.
+**Prevention:** Always use `strncpy` and manually ensure null-termination for fixed-size string arrays in the kernel, regardless of upstream path validation.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -102,7 +102,8 @@ static int tmpfs_dir_link(struct tmp_dirent *dir, const char *name, struct tmp_i
     }
 
     tmp_dirent_init(new_dirent);
-    strcpy(new_dirent->name, name);
+    strncpy(new_dirent->name, name, sizeof(new_dirent->name) - 1);
+    new_dirent->name[sizeof(new_dirent->name) - 1] = '\0';
     new_dirent->inode = tmp_inode_retain(child);
     new_dirent->index = dir->next_index++;
     new_dirent->parent = tmp_dirent_retain(dir);
@@ -448,7 +449,8 @@ static int tmpfs_readdir(struct fd *fd, struct dir_entry *entry) {
     tmpfs_fd_seekdir(fd, next_dirent);
 
     entry->inode = dirent->inode->stat.inode;
-    strcpy(entry->name, dirent->name);
+    strncpy(entry->name, dirent->name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     res = 1;
 
 out:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `fs/tmp.c` code used unbounded `strcpy` to copy strings into fixed-size character arrays (`char name[MAX_NAME + 1]`) for directory entries.
🎯 Impact: If a filename string exceeds `MAX_NAME` bytes, it could cause a buffer overflow, corrupting adjacent memory structures (such as `inode` pointers).
🔧 Fix: Replaced `strcpy` calls with `strncpy` specifying the maximum length (`sizeof(...) - 1`), and explicitly null-terminated the resulting string.
✅ Verification: `gcc -fsyntax-only fs/tmp.c` and ran E2E test suite.

---
*PR created automatically by Jules for task [13864483549857110442](https://jules.google.com/task/13864483549857110442) started by @emkey1*