### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack buffer overflow in TERM environment variable copy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** `fs/real.c` used a 20-byte buffer for formatting `/proc/self/fd/%d`, but the path prefix is 14 bytes and a 32-bit signed int can be 11 bytes, requiring at least 26 bytes. This allows a stack buffer overflow for very large file descriptors.
 **Learning:** Hardcoded buffer sizes for path formatting often fail to account for the maximum string length of integers.
 **Prevention:** Always allocate at least 32 bytes for paths containing PIDs or FDs, and consider using `snprintf` to avoid overflow entirely.
+
+## 2026-03-24 - Buffer Overflow in TERM Environment Variable Copy
+**Vulnerability:** A local variable `char envp[100] = {0};` allocated 100 bytes on the kernel stack in `main.c` and `tools/ptraceomatic.c`. The `TERM` environment variable was copied into this stack buffer using `strcpy`. Since environment variables are user-controlled, an excessively long `TERM` value would trigger a stack buffer overflow.
+**Learning:** Hardcoded stack buffer limits with unchecked string copies (`strcpy`) are a critical vulnerability vector, especially for environment variables which are easily controlled by external actors.
+**Prevention:** Always implement explicit bounds checking before performing string copies into stack-allocated buffers. Alternatively, dynamically allocate memory using `malloc()` with proper size calculation and a `NULL` check, then format safely with `snprintf()`, and finally free the memory when it's no longer needed.

--- a/main.c
+++ b/main.c
@@ -31,10 +31,24 @@ void *gen_exception_thread(void *parg) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp = malloc(1);
+    if (envp) {
+        envp[0] = '\0';
+    }
+    if (getenv("TERM")) {
+        const char *term = getenv("TERM");
+        size_t len = strlen("TERM=") + strlen(term) + 2;
+        char *new_envp = malloc(len);
+        if (new_envp) {
+            snprintf(new_envp, len, "TERM=%s", term);
+            new_envp[len - 1] = '\0';
+            if (envp) free(envp);
+            envp = new_envp;
+        }
+    }
     int err = xX_main_Xx(argc, argv, envp);
+    if (envp)
+        free(envp);
     if (err < 0) {
         fprintf(stderr, "xX_main_Xx: %s\n", strerror(-err));
         return err;

--- a/tools/ptraceomatic.c
+++ b/tools/ptraceomatic.c
@@ -459,10 +459,24 @@ static void prepare_tracee(int pid) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp = malloc(1);
+    if (envp) {
+        envp[0] = '\0';
+    }
+    if (getenv("TERM")) {
+        const char *term = getenv("TERM");
+        size_t len = strlen("TERM=") + strlen(term) + 2;
+        char *new_envp = malloc(len);
+        if (new_envp) {
+            snprintf(new_envp, len, "TERM=%s", term);
+            new_envp[len - 1] = '\0';
+            if (envp) free(envp);
+            envp = new_envp;
+        }
+    }
     int err = xX_main_Xx(argc, argv, envp);
+    if (envp)
+        free(envp);
     if (err < 0) {
         fprintf(stderr, "%s\n", strerror(-err));
         return err;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsafe string copy (`strcpy`) of the user-controlled `TERM` environment variable into a fixed 100-byte stack buffer (`char envp[100] = {0};`) in `main.c` and `tools/ptraceomatic.c`.
🎯 **Impact:** An attacker could craft a large `TERM` environment variable to overflow the stack buffer. Since this affects command-line argument handling and executable execution wrappers (via `xX_main_Xx`), it constitutes a critical Denial of Service (DoS) and potential Arbitrary Code Execution vector.
🔧 **Fix:** Changed `envp` from a fixed stack buffer to a dynamically allocated pointer. It accurately calculates the required size using `strlen`, correctly replicates double-null termination with `snprintf`, and explicitly `free`s the memory post-execution.
✅ **Verification:** Verified syntax manually and addressed code-review feedback to ensure proper dynamic memory allocation and cleanup paths. Added specific case-study to Sentinel's `sentinel.md` journal.

---
*PR created automatically by Jules for task [17466600497280333732](https://jules.google.com/task/17466600497280333732) started by @emkey1*