### PR TITLE
⚡ Bolt: Optimize redundant `strlen` in `sys_getdents_common`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2026-03-24 - Optimize redundant strlen in sys_getdents_common
+**Learning:** In `fs/dir.c` (`sys_getdents_common`), the `entry.name` length was calculated via `strlen` to calculate `max_reclen`, and then passed down to `fill_dirent_32` or `fill_dirent_64`, which executed `strlen` on the same string a second time. This causes an unnecessary O(N) string traversal in a tightly bound, highly iterated VFS loop.
+**Action:** Always pre-calculate `strlen` on immutable components in high-iteration loops and modify downstream callback signatures to accept the pre-calculated `size_t len` parameter. This cuts string traversal time by half.

--- a/fs/dir.c
+++ b/fs/dir.c
@@ -35,22 +35,20 @@ struct linux_dirent64_ {
     char name[];
 } __attribute__((packed));
 
-size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent_, name) + namelen + 1; // name, null terminator, type
     memcpy(dirent->name, name, namelen);
     *((char *) dirent + dirent->reclen - 1) = type;
     return dirent->reclen;
 }
 
-size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent64_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent64_, name) + namelen; // name, null terminator
     dirent->type = type;
     memcpy(dirent->name, name, namelen);
@@ -58,7 +56,7 @@ size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char 
 }
 
 int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
-        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int)) {
+        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, size_t, int)) {
     STRACE("getdents(%d, %#x, %#x)", f, dirents, count);
     struct fd *fd = f_get(f);
     if (fd == NULL)
@@ -85,14 +83,16 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         if (err == 0)
             break;
 
-        size_t max_reclen = sizeof(struct linux_dirent64_) + strlen(entry.name) + 4;
+        size_t name_len = strlen(entry.name);
+        size_t namelen_with_null = name_len + 1;
+        size_t max_reclen = sizeof(struct linux_dirent64_) + name_len + 4;
         char dirent_data[max_reclen];
         dirent_data[0] = 0;
         ino_t inode = entry.inode;
         off_t_ offset = fd_telldir(fd);
         const char *name = entry.name;
         int type = 0;
-        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type);
+        size_t reclen = fill_dirent(dirent_data, inode, offset, name, namelen_with_null, type);
         if (printed < 20) {
             STRACE(" {inode=%d, offset=%d, name=%s, type=%d, reclen=%d}",
                     inode, offset, name, type, reclen);


### PR DESCRIPTION
💡 **What:** Optimized `sys_getdents_common` to calculate `strlen(entry.name)` once and pass the result (`size_t namelen`) to `fill_dirent_32` and `fill_dirent_64`.
🎯 **Why:** Previously, the `getdents` system call calculated `strlen(entry.name)` within the loop to determine `max_reclen` and then called it a second time inside the `fill_dirent` callback. This redundant O(N) traversal creates an unnecessary performance bottleneck inside a tight, frequently-called VFS loop.
📊 **Impact:** Reduces `strlen` calls inside `sys_getdents` by exactly 50%.
🔬 **Measurement:** Compile and observe standard `sys_getdents` processing time. Test syntax compiled cleanly via `gcc -fsyntax-only fs/dir.c -I. -D_GNU_SOURCE`.

---
*PR created automatically by Jules for task [17466050127117313654](https://jules.google.com/task/17466050127117313654) started by @emkey1*