### PR TITLE
🎨 Palette: Preserve superclass traits in ArrowBarButton

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Destructive Updates to accessibilityTraits
 **Learning:** Overwriting `accessibilityTraits` using the assignment operator (`=`) when toggling states (e.g., `selected ? UIAccessibilityTraitSelected : 0`) deletes all inherent traits, such as `UIAccessibilityTraitButton`, causing VoiceOver to no longer announce the control type correctly.
 **Action:** Always use bitwise OR (`|=`) to add traits and bitwise AND NOT (`&= ~`) to remove traits to preserve existing state.
+
+## 2024-05-27 - Overriding accessibilityTraits Getter Destructively
+**Learning:** When creating custom accessible controls by subclassing existing ones, completely overriding the `accessibilityTraits` getter (e.g., `return UIAccessibilityTraitAdjustable;`) destructively removes inherent superclass traits (such as `UIAccessibilityTraitButton`).
+**Action:** Always use a bitwise OR with `[super accessibilityTraits]` (e.g., `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`) when overriding the `accessibilityTraits` getter to preserve necessary inherited traits.

--- a/app/ArrowBarButton.m
+++ b/app/ArrowBarButton.m
@@ -62,7 +62,7 @@ static CGPoint anchors[] = {
     return YES;
 }
 - (UIAccessibilityTraits)accessibilityTraits {
-    return UIAccessibilityTraitAdjustable;
+    return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;
 }
 - (NSString *)accessibilityLabel {
     return self.accessibilityUpDown ? @"Arrow Keys Up or Down" : @"Arrow Keys Left or Right";


### PR DESCRIPTION
💡 **What:** Preserved inherited accessibility traits in `ArrowBarButton` when extending it to be an adjustable control. Recorded the learning in the journal.
🎯 **Why:** Previously, returning *only* `UIAccessibilityTraitAdjustable` completely overwrote any inherent traits provided by the superclass (such as `UIAccessibilityTraitButton`). By changing it to `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`, it ensures VoiceOver properly announces both the inherent control type and its adjustability.
♿ **Accessibility:** VoiceOver will now accurately announce this element as a button while also retaining its adjustable nature.

---
*PR created automatically by Jules for task [1454959440779130958](https://jules.google.com/task/1454959440779130958) started by @emkey1*