### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in environment variable setup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** `fs/real.c` used a 20-byte buffer for formatting `/proc/self/fd/%d`, but the path prefix is 14 bytes and a 32-bit signed int can be 11 bytes, requiring at least 26 bytes. This allows a stack buffer overflow for very large file descriptors.
 **Learning:** Hardcoded buffer sizes for path formatting often fail to account for the maximum string length of integers.
 **Prevention:** Always allocate at least 32 bytes for paths containing PIDs or FDs, and consider using `snprintf` to avoid overflow entirely.
+
+## 2026-03-25 - Buffer Overflow in Environment Variable Setup
+**Vulnerability:** A static stack buffer (`char envp[100] = {0};`) was used to construct the `TERM` environment variable in `main.c` and `tools/ptraceomatic.c`. A malicious user or system configuration could supply a `TERM` string larger than 99 characters, causing `strcpy` to overflow the stack buffer, leading to memory corruption, denial of service, or potential arbitrary code execution.
+**Learning:** Even simple setup code running early in the application lifecycle can introduce critical vulnerabilities if stack-allocated buffers are copied into using unbounded functions like `strcpy`. The iSH kernel also requires these environment buffers to be double-null terminated.
+**Prevention:** Always use dynamic allocation (`malloc` or `realloc`) for user- or environment-controlled inputs and format strings safely using `snprintf`. Remember to include proper cleanup (e.g. `free(envp)`) to avoid memory leaks. Ensure that kernel requirements, like double-null termination, are explicitly managed.

--- a/main.c
+++ b/main.c
@@ -31,10 +31,23 @@ void *gen_exception_thread(void *parg) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp = malloc(1);
+    if (envp) envp[0] = '\0';
+
+    char *term = getenv("TERM");
+    if (term) {
+        size_t len = strlen("TERM=") + strlen(term) + 2; // +1 for null, +1 for double null (iSH requires double null terminated environment strings)
+        char *new_envp = realloc(envp, len);
+        if (new_envp) {
+            envp = new_envp;
+            snprintf(envp, len, "TERM=%s", term);
+            envp[len - 1] = '\0'; // ensure double null termination
+        }
+    }
+
     int err = xX_main_Xx(argc, argv, envp);
+    free(envp);
+
     if (err < 0) {
         fprintf(stderr, "xX_main_Xx: %s\n", strerror(-err));
         return err;

--- a/tools/ptraceomatic.c
+++ b/tools/ptraceomatic.c
@@ -3,6 +3,7 @@
 // working the same.
 // Many apologies for the messy code.
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <signal.h>
 #include <unistd.h>
@@ -459,10 +460,23 @@ static void prepare_tracee(int pid) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp = malloc(1);
+    if (envp) envp[0] = '\0';
+
+    char *term = getenv("TERM");
+    if (term) {
+        size_t len = strlen("TERM=") + strlen(term) + 2; // +1 for null, +1 for double null
+        char *new_envp = realloc(envp, len);
+        if (new_envp) {
+            envp = new_envp;
+            snprintf(envp, len, "TERM=%s", term);
+            envp[len - 1] = '\0'; // ensure double null termination
+        }
+    }
+
     int err = xX_main_Xx(argc, argv, envp);
+    free(envp);
+
     if (err < 0) {
         fprintf(stderr, "%s\n", strerror(-err));
         return err;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `main.c` and `tools/ptraceomatic.c` allocated a fixed 100-byte stack buffer `char envp[100] = {0};` to store the environment variable `TERM`. The code used `strcpy` to copy the `TERM=value` string into the `envp` buffer. A long `TERM` environment variable would overflow the buffer, potentially leading to a denial of service or arbitrary code execution.
🎯 Impact: Exploitation of stack buffer overflow leading to DoS or memory corruption early in the app lifecycle.
🔧 Fix: Replaced static array with dynamic allocation. Used `snprintf` to safely format the `TERM` string into the `malloc`/`realloc`-allocated heap buffer. Enforced double-null termination logic. Called `free(envp)` after `xX_main_Xx` to prevent memory leaks.
✅ Verification: Ran `gcc -fsyntax-only` on the modified files to verify no syntax errors. Test suite could not build in the sandbox but logic was thoroughly reviewed and validated via a scratchpad file.

---
*PR created automatically by Jules for task [1144358475457057758](https://jules.google.com/task/1144358475457057758) started by @emkey1*