### PR TITLE
⚡ Bolt: optimize sys_getdents_common by pre-calculating string lengths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-03-24 - Avoid redundant strlen() inside VFS getdents loop
+**Learning:** In `fs/dir.c` (`sys_getdents_common`), the length of `entry.name` was being evaluated multiple times via `strlen()` for every directory entry: once in `max_reclen` calculation and again inside the `fill_dirent` callbacks (`fill_dirent_32` / `fill_dirent_64`). This redundancy creates unnecessary overhead inside the O(N) directory traversal loop.
+**Action:** Pre-calculate `strlen()` once for each directory entry during the traversal loop, and pass the string length down as a parameter to the helper callbacks, converting subsequent O(N) traversals to O(1) assignments.

--- a/fs/dir.c
+++ b/fs/dir.c
@@ -35,22 +35,20 @@ struct linux_dirent64_ {
     char name[];
 } __attribute__((packed));
 
-size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type, size_t namelen) {
     struct linux_dirent_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent_, name) + namelen + 1; // name, null terminator, type
     memcpy(dirent->name, name, namelen);
     *((char *) dirent + dirent->reclen - 1) = type;
     return dirent->reclen;
 }
 
-size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type, size_t namelen) {
     struct linux_dirent64_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent64_, name) + namelen; // name, null terminator
     dirent->type = type;
     memcpy(dirent->name, name, namelen);
@@ -58,7 +56,7 @@ size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char 
 }
 
 int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
-        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int)) {
+        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int, size_t)) {
     STRACE("getdents(%d, %#x, %#x)", f, dirents, count);
     struct fd *fd = f_get(f);
     if (fd == NULL)
@@ -85,14 +83,15 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         if (err == 0)
             break;
 
-        size_t max_reclen = sizeof(struct linux_dirent64_) + strlen(entry.name) + 4;
+        const char *name = entry.name;
+        size_t namelen = strlen(name) + 1; // Include null terminator
+        size_t max_reclen = sizeof(struct linux_dirent64_) + namelen + 3;
         char dirent_data[max_reclen];
         dirent_data[0] = 0;
         ino_t inode = entry.inode;
         off_t_ offset = fd_telldir(fd);
-        const char *name = entry.name;
         int type = 0;
-        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type);
+        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type, namelen);
         if (printed < 20) {
             STRACE(" {inode=%d, offset=%d, name=%s, type=%d, reclen=%d}",
                     inode, offset, name, type, reclen);


### PR DESCRIPTION
💡 What: Optimized `sys_getdents_common` in `fs/dir.c` to pre-calculate the directory entry's name length exactly once and pass it down to `fill_dirent_32` and `fill_dirent_64`.
🎯 Why: Inside the `while (true)` directory traversal loop, `strlen` was being redundantly executed multiple times on the exact same string—first for allocation bounds, then again internally in the callback. For deep or large directory reads, avoiding this redundant O(N) recalculation improves VFS performance.
📊 Impact: Reduces string length calculations per directory entry by 50%.
🔬 Measurement: Verified that the pointer offsets and sizes calculate to the exact same bounds as before. Also validated syntax compilation of `fs/dir.c` to ensure there are no build issues. Evaluated safety and recorded the findings in the Bolt journal.

---
*PR created automatically by Jules for task [15653649297018390937](https://jules.google.com/task/15653649297018390937) started by @emkey1*