### PR TITLE
🎨 Palette: [Accessibility] Preserve superclass accessibility traits on ArrowBarButton

### DIFF
--- a/app/ArrowBarButton.m
+++ b/app/ArrowBarButton.m
@@ -62,7 +62,7 @@ static CGPoint anchors[] = {
     return YES;
 }
 - (UIAccessibilityTraits)accessibilityTraits {
-    return UIAccessibilityTraitAdjustable;
+    return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;
 }
 - (NSString *)accessibilityLabel {
     return self.accessibilityUpDown ? @"Arrow Keys Up or Down" : @"Arrow Keys Left or Right";


### PR DESCRIPTION
💡 What: The UX enhancement added: `[super accessibilityTraits]` was added to the `accessibilityTraits` getter in `ArrowBarButton.m`.
🎯 Why: The user problem it solves: Prevents VoiceOver from losing critical inherited traits like `UIAccessibilityTraitButton`, which helps visually impaired users understand the control type.
📸 Before/After: Visual changes were not made.
♿ Accessibility: Preserves inherent control traits to correctly announce the button's purpose to screen readers.

---
*PR created automatically by Jules for task [2770331100068670516](https://jules.google.com/task/2770331100068670516) started by @emkey1*