### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix envp stack buffer overflow in main and ptraceomatic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,3 +36,8 @@
 **Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[MAX_NAME + 1]`) in `fs/tmp.c`.
 **Learning:** Legacy VFS and temporary filesystem code often lacks explicit bounds checking, relying on higher-level path validation. This creates defense-in-depth vulnerabilities if `MAX_NAME` bounds are ever exceeded.
 **Prevention:** Always use `strncpy` and manually ensure null-termination for fixed-size string arrays in the kernel, regardless of upstream path validation.
+
+## $(date +%Y-%m-%d) - Buffer Overflow in Environment Variables Initialization
+**Vulnerability:** The `envp` buffer in `main.c` and `tools/ptraceomatic.c` was allocated as a fixed-size stack array (`char envp[100]`). Unbounded use of `strcpy` to copy the `TERM` environment variable into this buffer allowed a stack buffer overflow if the variable exceeded the allocated size.
+**Learning:** Fixed-size buffers combined with `strcpy` for handling environment variables present a significant security risk, as the environment can be trivially controlled by the user or upstream process.
+**Prevention:** Environment variables and other dynamically sized inputs must be dynamically allocated using `malloc`, constructed using `snprintf` to ensure bounds limits, and properly null-terminated. Allocated memory should always be freed (`free(envp)`) on exit paths to prevent memory leaks.

--- a/main.c
+++ b/main.c
@@ -31,10 +31,27 @@ void *gen_exception_thread(void *parg) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp = NULL;
+    char *term = getenv("TERM");
+    if (term) {
+        size_t envp_len = strlen("TERM=") + strlen(term) + 2;
+        envp = malloc(envp_len);
+        if (envp) {
+            snprintf(envp, envp_len, "TERM=%s", term);
+            envp[envp_len - 1] = '\0';
+        }
+    } else {
+        envp = malloc(1);
+        if (envp) envp[0] = '\0';
+    }
+    if (!envp) {
+        fprintf(stderr, "xX_main_Xx: %s\n", strerror(ENOMEM));
+        return -ENOMEM;
+    }
+
     int err = xX_main_Xx(argc, argv, envp);
+    free(envp);
+
     if (err < 0) {
         fprintf(stderr, "xX_main_Xx: %s\n", strerror(-err));
         return err;

--- a/tools/ptraceomatic.c
+++ b/tools/ptraceomatic.c
@@ -459,10 +459,27 @@ static void prepare_tracee(int pid) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp = NULL;
+    char *term = getenv("TERM");
+    if (term) {
+        size_t envp_len = strlen("TERM=") + strlen(term) + 2;
+        envp = malloc(envp_len);
+        if (envp) {
+            snprintf(envp, envp_len, "TERM=%s", term);
+            envp[envp_len - 1] = '\0';
+        }
+    } else {
+        envp = malloc(1);
+        if (envp) envp[0] = '\0';
+    }
+    if (!envp) {
+        fprintf(stderr, "%s\n", strerror(ENOMEM));
+        return -ENOMEM;
+    }
+
     int err = xX_main_Xx(argc, argv, envp);
+    free(envp);
+
     if (err < 0) {
         fprintf(stderr, "%s\n", strerror(-err));
         return err;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded `strcpy` to a fixed-size `100`-byte stack array (`char envp[100]`) when processing the `TERM` environment variable.
🎯 **Impact:** Potential stack buffer overflow leading to application crash or arbitrary code execution if an attacker or automated script controls the `TERM` environment variable. Also vulnerable to pointer arithmetic out-of-bounds reads (`getenv("TERM") - strlen("TERM") - 1`).
🔧 **Fix:** Replaced the stack buffer with a dynamically allocated buffer via `malloc()`. Used `snprintf()` to copy the content safely and bounds-checked. Handled memory cleanup with `free()`. Also added proper handling for `malloc` failures returning `-ENOMEM`. Recorded findings to the Sentinel journal.
✅ **Verification:** Verified syntax and tested execution in a sandboxed dummy file to confirm behavior works exactly as intended and preserves the double null-termination requirement for execve arguments. E2E tests verified correctly.

---
*PR created automatically by Jules for task [2305231557941452883](https://jules.google.com/task/2305231557941452883) started by @emkey1*