### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stack buffer overflow DoS via TERM environment variable

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,3 +36,7 @@
 **Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[MAX_NAME + 1]`) in `fs/tmp.c`.
 **Learning:** Legacy VFS and temporary filesystem code often lacks explicit bounds checking, relying on higher-level path validation. This creates defense-in-depth vulnerabilities if `MAX_NAME` bounds are ever exceeded.
 **Prevention:** Always use `strncpy` and manually ensure null-termination for fixed-size string arrays in the kernel, regardless of upstream path validation.
+## 2026-03-26 - Buffer Overflow DoS via TERM Environment Variable
+**Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
+**Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
+**Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.

--- a/main.c
+++ b/main.c
@@ -31,10 +31,29 @@ void *gen_exception_thread(void *parg) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp;
+    char *term = getenv("TERM");
+    if (term) {
+        size_t term_len = strlen(term);
+        // "TERM=" + term + "\0" + "\0"
+        envp = malloc(5 + term_len + 2);
+        if (!envp) {
+            fprintf(stderr, "malloc: %s\n", strerror(ENOMEM));
+            return -ENOMEM;
+        }
+        snprintf(envp, 5 + term_len + 1, "TERM=%s", term);
+        envp[5 + term_len + 1] = '\0'; // double null terminator
+    } else {
+        envp = malloc(1);
+        if (!envp) {
+            fprintf(stderr, "malloc: %s\n", strerror(ENOMEM));
+            return -ENOMEM;
+        }
+        envp[0] = '\0';
+    }
+
     int err = xX_main_Xx(argc, argv, envp);
+    free(envp);
     if (err < 0) {
         fprintf(stderr, "xX_main_Xx: %s\n", strerror(-err));
         return err;

--- a/tools/ptraceomatic.c
+++ b/tools/ptraceomatic.c
@@ -459,10 +459,29 @@ static void prepare_tracee(int pid) {
 }
 
 int main(int argc, char *const argv[]) {
-    char envp[100] = {0};
-    if (getenv("TERM"))
-        strcpy(envp, getenv("TERM") - strlen("TERM") - 1);
+    char *envp;
+    char *term = getenv("TERM");
+    if (term) {
+        size_t term_len = strlen(term);
+        // "TERM=" + term + "\0" + "\0"
+        envp = malloc(5 + term_len + 2);
+        if (!envp) {
+            fprintf(stderr, "malloc: %s\n", strerror(ENOMEM));
+            return -ENOMEM;
+        }
+        snprintf(envp, 5 + term_len + 1, "TERM=%s", term);
+        envp[5 + term_len + 1] = '\0'; // double null terminator
+    } else {
+        envp = malloc(1);
+        if (!envp) {
+            fprintf(stderr, "malloc: %s\n", strerror(ENOMEM));
+            return -ENOMEM;
+        }
+        envp[0] = '\0';
+    }
+
     int err = xX_main_Xx(argc, argv, envp);
+    free(envp);
     if (err < 0) {
         fprintf(stderr, "%s\n", strerror(-err));
         return err;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsafe use of `strcpy` to copy the `TERM` environment variable into a fixed 100-byte stack-allocated character array (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c`.
🎯 **Impact:** Supplying a large `TERM` environment variable would overflow the local stack buffer, causing stack memory corruption. This leads to a Denial of Service (DoS) and potentially arbitrary code execution at initialization.
🔧 **Fix:** Replaced the stack buffer and `strcpy` pattern with dynamic bounds-checked allocation (`malloc` + `snprintf`) proportional to the `TERM` string length, safely injecting the exact `TERM=...` format with the required double null-terminators. Memory is correctly freed before function exit.
✅ **Verification:** Verified syntax correctness using `gcc -fsyntax-only` in the sandbox. `xX_main_Xx` bounds and parameters were thoroughly verified. Added security journaling entry.

---
*PR created automatically by Jules for task [12747769393467877727](https://jules.google.com/task/12747769393467877727) started by @emkey1*