### PR TITLE
🎨 Palette: Add accessibility traits for default root cell

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-27 - Overriding accessibilityTraits Getter Destructively
 **Learning:** When creating custom accessible controls by subclassing existing ones, completely overriding the `accessibilityTraits` getter (e.g., `return UIAccessibilityTraitAdjustable;`) destructively removes inherent superclass traits (such as `UIAccessibilityTraitButton`).
 **Action:** Always use a bitwise OR with `[super accessibilityTraits]` (e.g., `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`) when overriding the `accessibilityTraits` getter to preserve necessary inherited traits.
+
+## 2024-05-28 - UITableViewCell Default State Accessibility
+**Learning:** When using different reuse identifiers for default/selected states (e.g., "Default Root" vs "Root"), the dequeued cells still need explicit accessibility traits to communicate their status to VoiceOver users.
+**Action:** Always explicitly add `UIAccessibilityTraitSelected` for the default/selected state cell and clear it for others.

--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -45,10 +45,18 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    BOOL isDefault = [Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot];
+    if (isDefault)
         ident = @"Default Root";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+
+    if (isDefault) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
+
     return cell;
 }
 


### PR DESCRIPTION
💡 What: Adds `UIAccessibilityTraitSelected` to the default root cell in `RootsTableViewController.m`.
🎯 Why: VoiceOver users had no way of distinguishing the currently active default root from other filesystems in the list. This fix also implements the correct cell reuse pattern.
♿ Accessibility: Ensures the default root is announced as selected to screen reader users and prevents stale accessibility traits on reused cells.

---
*PR created automatically by Jules for task [4414196341677411405](https://jules.google.com/task/4414196341677411405) started by @emkey1*