### PR TITLE
⚡ Bolt: Replace O(N) strlen with O(1) pointer arithmetic in tmpfs_getpath

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2026-03-25 - Avoid O(N) strlen in backward string construction
+**Learning:** In `fs/tmp.c` (`tmpfs_getpath`), strings constructed backwards from the end of a buffer (like `buf + MAX_PATH - 1`) do not need `strlen()` to determine their length before copying or moving. `strlen()` causes an unnecessary O(N) traversal.
+**Action:** Instead of `strlen(p)`, use pointer arithmetic `(buf + MAX_PATH - 1) - p` to calculate the exact string length in O(1) time when the buffer boundaries and current pointer are known.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -590,7 +590,9 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    // Bolt: Calculate length using pointer arithmetic to avoid redundant O(N) recalculation
+    size_t len = (buf + MAX_PATH - 1) - p;
+    memmove(buf, p, len + 1);
     return 0;
 }
 


### PR DESCRIPTION
💡 What: Replaced `strlen(p)` with pointer arithmetic `(buf + MAX_PATH - 1) - p` in `tmpfs_getpath`.
🎯 Why: `tmpfs_getpath` constructs the path backwards starting from the end of the buffer. Calling `strlen()` on the final string performs a redundant O(N) traversal when the exact length is already known via the pointer distance from the end of the buffer.
📊 Impact: O(1) length calculation instead of O(N), improving performance of `tmpfs_getpath`.
🔬 Measurement: Observe faster execution of `tmpfs_getpath` operations by eliminating O(N) string traversal.

---
*PR created automatically by Jules for task [4025177183931276943](https://jules.google.com/task/4025177183931276943) started by @emkey1*