### PR TITLE
🎨 Palette: Add accessibility trait for default root cell

### DIFF
--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -72,10 +72,16 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    BOOL isDefault = [Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot];
+    if (isDefault)
         ident = @"Default Root";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+    if (isDefault) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` to the default filesystem root cell and cleared it for unselected cells.
🎯 Why: Without this trait, VoiceOver users rely purely on visual layout (subtitle presence, etc) to identify the default root filesystem. Additionally, when UITableViewCells are reused, failing to explicitly clear accessibility traits can lead to stale state being read.
♿ Accessibility: Ensures VoiceOver correctly announces the selected/default filesystem root to users.

---
*PR created automatically by Jules for task [13494879109207423643](https://jules.google.com/task/13494879109207423643) started by @emkey1*