### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace unsafe strcpy with strncpy in fs code

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2024-05-18 - Replace unsafe strcpy calls with strncpy in filesystem/proc code
+**Vulnerability:** Unbounded string copies (`strcpy`) writing dynamic user/OS inputs (like `dirent->d_name` or `data->name`) to fixed-size char arrays in `fs/real.c` and `fs/proc/pid.c`.
+**Learning:** Legacy VFS and proc filesystem code often lacks explicit bounds checking, relying on assumptions about maximum path or filename lengths. This creates defense-in-depth vulnerabilities (buffer overflows) if these assumptions are violated.
+**Prevention:** Always use `strncpy` (or similar bounded functions) and manually ensure null-termination for fixed-size string arrays in the kernel, regardless of upstream path validation or host OS assumptions.

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -427,7 +427,8 @@ void proc_maps_dump(struct task *task, struct proc_data *buf) {
             static const char s[] = "[stack]";
             memcpy(path, s, sizeof(s));
         } else if (data->name != NULL) {
-            strcpy(path, data->name);
+            strncpy(path, data->name, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
         } else if (data->fd != NULL) {
             generic_getpath(start_pt->data->fd, path);
         }

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `fs/real.c` and `fs/proc/pid.c` used unbounded `strcpy` to copy dynamic strings (`dirent->d_name` and `data->name`) into fixed-size buffers (`entry->name` and `path`), posing a risk of buffer overflows if the input length exceeds the buffer sizes.
🎯 Impact: If malicious or unexpectedly long inputs are provided, it could lead to stack or heap corruption, potentially resulting in crashes or code execution within the kernel.
🔧 Fix: Replaced `strcpy` with `strncpy` and manually enforced null-termination to ensure buffer boundaries are never exceeded.
✅ Verification: Verified syntax with `gcc -fsyntax-only` and ran E2E test suite.

---
*PR created automatically by Jules for task [9828232919010130761](https://jules.google.com/task/9828232919010130761) started by @emkey1*