### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix buffer overflow in procfs component names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2026-03-27 - Buffer Overflow in procfs entry name allocations
+**Vulnerability:** `fs/proc.c` allocated `char entry_name[MAX_NAME];` and `char component[MAX_NAME];`. If the name length was exactly `MAX_NAME`, adding the null terminator would cause a 1-byte stack buffer overflow.
+**Learning:** Arrays intended to store strings of maximum length `MAX_NAME` must be allocated with size `MAX_NAME + 1` to account for the null terminator.
+**Prevention:** Always allocate `MAX_NAME + 1` for string buffers representing file paths or names, or use dynamic allocation when sizes are unbounded.

--- a/fs/proc.c
+++ b/fs/proc.c
@@ -17,7 +17,7 @@ static int proc_lookup(const char *path, struct proc_entry *entry) {
 
         unsigned long index = 0;
         struct proc_entry next_entry = {0};
-        char entry_name[MAX_NAME];
+        char entry_name[MAX_NAME + 1];
         while (proc_dir_read(entry, &index, &next_entry)) {
             // tack on some dynamically generated attributes
             if (next_entry.meta->parent == NULL)
@@ -63,7 +63,7 @@ static int proc_getpath(struct fd *fd, char *buf) {
     p[0] = '\0';
     struct proc_entry entry = fd->proc.entry;
     while (entry.meta != &proc_root) {
-        char component[MAX_NAME];
+        char component[MAX_NAME + 1];
         proc_entry_getname(&entry, component);
         size_t component_len = strlen(component) + 1; // plus one for the slash
         p -= component_len;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Buffer overflow in `fs/proc.c` due to missing `+ 1` for the null terminator in `entry_name` and `component` array allocations.
🎯 Impact: If a process name length was exactly `MAX_NAME`, adding the null terminator would cause a 1-byte stack buffer overflow, potentially crashing the system.
🔧 Fix: Allocated `MAX_NAME + 1` for `entry_name` and `component` arrays.
✅ Verification: Verified syntax and ran the E2E test suite.

---
*PR created automatically by Jules for task [3605924169337960977](https://jules.google.com/task/3605924169337960977) started by @emkey1*