### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential buffer overflow in realfs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-03-27 - Replace unsafe strcpy in realfs_readdir
+**Vulnerability:** Unbounded string copy (`strcpy`) of host filesystem directory names (`dirent->d_name`) into fixed-size kernel struct arrays (`entry->name` of size `NAME_MAX + 1`) in `fs/real.c`.
+**Learning:** Data crossing the boundary from the host OS into the emulator must be explicitly bounds-checked, as host filename limits may exceed or mismatch expected internal emulator limits, leading to buffer overflows.
+**Prevention:** Use `strncpy` with explicit null-termination when copying data from host `dirent` structures into emulator directory entries.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential buffer overflow due to unbounded `strcpy` of host filesystem directory names (`dirent->d_name`) into fixed-size kernel struct arrays (`entry->name` of size `NAME_MAX + 1`).
🎯 Impact: If the host filesystem returns a filename longer than `NAME_MAX`, it could trigger a stack buffer overflow, leading to memory corruption or potential arbitrary code execution.
🔧 Fix: Replaced `strcpy` with `strncpy`, explicitly bounding the copy to `sizeof(entry->name) - 1` and appending a null terminator to ensure safety.
✅ Verification: Ran the E2E tests, and compiled `fs/real.c` with `gcc -fsyntax-only` to ensure no syntax errors.

---
*PR created automatically by Jules for task [3545019240968849907](https://jules.google.com/task/3545019240968849907) started by @emkey1*