### PR TITLE
🛡️ Sentinel: [HIGH] Fix inverted strncpy in flock_from_file_lock

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2024-04-02 - Fix inverted strncpy in flock_from_file_lock
+**Vulnerability:** In `fs/lock.c`, `flock_from_file_lock` copied uninitialized user data from `flock->comm` into kernel state `lock->comm` due to an inverted `strncpy` argument order.
+**Learning:** Argument ordering in `strncpy(dest, src, size)` is easily flipped when translating kernel state structures to user state structures, leading to kernel memory corruption.
+**Prevention:** Always ensure string copy directions flow from kernel to user when populating a user `flock_` structure from a kernel `file_lock`.

--- a/fs/lock.c
+++ b/fs/lock.c
@@ -197,7 +197,7 @@ static int flock_from_file_lock(struct file_lock *lock, struct flock_ *flock) {
     else
         flock->len = 0;
     flock->pid = lock->pid;
-    strncpy(lock->comm, flock->comm, 16);
+    strncpy(flock->comm, lock->comm, 16);
     return 0;
 }
 

--- a/syntax_test.c
+++ b/syntax_test.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <string.h>
+#include "kernel/task.h"
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `flock_from_file_lock` function in `fs/lock.c` used an inverted `strncpy` argument order, copying uninitialized user data into kernel memory (`lock->comm`).
🎯 Impact: Potential kernel memory corruption by overwriting internal lock structures with attacker-controlled data from a user-supplied struct.
🔧 Fix: Corrected the order to `strncpy(flock->comm, lock->comm, 16);` so that kernel state flows to the user struct safely.
✅ Verification: Syntax verified, and E2E test suite executed.

---
*PR created automatically by Jules for task [17210617571556955005](https://jules.google.com/task/17210617571556955005) started by @emkey1*