### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in realfs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2026-03-27 - Buffer Overflow in realfs_readdir
+**Vulnerability:** Unbounded `strcpy` in `fs/real.c` when copying `dirent->d_name` from the host OS into the fixed-size `entry->name` buffer. This could lead to a buffer overflow if a host file has an unexpectedly long name.
+**Learning:** Data crossing the boundary from the host OS to the emulated environment must always be explicitly bounds-checked, even if host systems typically enforce similar path length restrictions.
+**Prevention:** Always use bounded string copy functions like `strncpy` when transferring data into fixed-size kernel or emulator buffers, followed by manual null-termination.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded `strcpy` used to copy directory entry names from the host OS into a fixed-size buffer in `realfs_readdir`.
🎯 Impact: A crafted long filename on the host file system could trigger a stack or heap buffer overflow in the emulator process when listed.
🔧 Fix: Replaced `strcpy` with `strncpy` and explicit null-termination to enforce buffer boundaries.
✅ Verification: Ran `./tests/e2e/e2e.bash` and verified syntax using `gcc -fsyntax-only`.

---
*PR created automatically by Jules for task [4785670844078511288](https://jules.google.com/task/4785670844078511288) started by @emkey1*