### PR TITLE
⚡ Bolt: Optimize strlen in read_proc_line loop

### DIFF
--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,16 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+
+    // Bolt: Cache strlen(name) to prevent redundant O(N) recalculations
+    // during each iteration of the while loop reading lines from proc files.
+    size_t name_len = strlen(name);
+
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Hoisted `strlen(name)` outside of the loop in `read_proc_line` function in `platform/linux.c` and cached it in `name_len`.
🎯 Why: `strlen(name)` was being called up to twice on every iteration of the `while` loop when reading lines from files like `/proc/meminfo` and `/proc/stat`. The variable `name` does not change across iterations, causing unnecessary O(N) recalculations for a loop-invariant string length.
📊 Impact: Reduces redundant O(N) string length calculations to a single O(1) lookup and slightly improves loop performance when parsing host system stat and meminfo files.
🔬 Measurement: Verified the code compiles and passes syntax checks (`gcc -fsyntax-only`). Performance improvement can be measured by profiling the read operations to proc files on platforms where it applies.

---
*PR created automatically by Jules for task [10247797096962730920](https://jules.google.com/task/10247797096962730920) started by @emkey1*