### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in realfs_readdir

### DIFF
--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Buffer overflow in `realfs_readdir` caused by unbounded `strcpy(entry->name, dirent->d_name);`. Host directory names could potentially exceed the emulator's internal `NAME_MAX` limit and overflow the stack buffer.
🎯 Impact: Potential memory corruption, denial of service, or arbitrary code execution within the emulator context if a maliciously long directory name is encountered on the host filesystem.
🔧 Fix: Replaced `strcpy` with `strncpy`, explicitly capping the copy length to `sizeof(entry->name) - 1`, and manually applying a null-terminator.
✅ Verification: Ran `gcc -fsyntax-only fs/real.c -I. -D_GNU_SOURCE` and `./tests/e2e/e2e.bash` to ensure the change compiles and does not break existing functionality.

---
*PR created automatically by Jules for task [1221115482641757009](https://jules.google.com/task/1221115482641757009) started by @emkey1*