### PR TITLE
🎨 Palette: Add accessibility labels and button traits to app UI elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-27 - Overriding accessibilityTraits Getter Destructively
 **Learning:** When creating custom accessible controls by subclassing existing ones, completely overriding the `accessibilityTraits` getter (e.g., `return UIAccessibilityTraitAdjustable;`) destructively removes inherent superclass traits (such as `UIAccessibilityTraitButton`).
 **Action:** Always use a bitwise OR with `[super accessibilityTraits]` (e.g., `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`) when overriding the `accessibilityTraits` getter to preserve necessary inherited traits.
+
+## $(date +%Y-%m-%d) - Actionable Table View Cells & Text Field Labels
+**Learning:** Static `UITableViewCell`s used as actions do not inherently have `UIAccessibilityTraitButton`, leaving screen reader users unaware that they are interactive. Furthermore, `UITextField`s placed inside table view cells may not automatically inherit the cell's `textLabel` as their accessibility label, leading to "Text field" announcements without context.
+**Action:** Always explicitly add `UIAccessibilityTraitButton` to table view cells that act as buttons (using `tableView:willDisplayCell:forRowAtIndexPath:` or in `awakeFromNib`), and explicitly assign `accessibilityLabel`s to all `UITextField`s to ensure robust screen reader context.

--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -42,6 +42,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.launchCommandField.accessibilityLabel = @"Launch Command";
+    self.bootCommandField.accessibilityLabel = @"Boot Command";
     [self _updateUI];
     if (self.recoveryMode) {
         self.includeDebugPanel = YES;

--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -142,6 +142,7 @@
     self.navigationItem.title = self.rootName;
     self.nameField.enabled = !self.isDefaultRoot;
     self.nameField.clearButtonMode = self.isDefaultRoot ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
+    self.nameField.accessibilityLabel = @"Filesystem Name";
     self.deleteLabel.enabled = !self.isDefaultRoot;
     self.deleteCell.selectionStyle = !self.isDefaultRoot ? UITableViewCellSelectionStyleDefault : UITableViewCellSelectionStyleNone;
     [self.tableView reloadData];
@@ -166,6 +167,21 @@
 
 - (BOOL)isDefaultRoot {
     return [self.rootName isEqualToString:Roots.instance.defaultRoot];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == 0 && (indexPath.row == 1 || indexPath.row == 2)) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+    } else if (indexPath.section == 1 && indexPath.row == 0) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+    } else if (indexPath.section == 2 && indexPath.row == 0) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+        if (self.isDefaultRoot) {
+            cell.accessibilityTraits |= UIAccessibilityTraitNotEnabled;
+        } else {
+            cell.accessibilityTraits &= ~UIAccessibilityTraitNotEnabled;
+        }
+    }
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {

--- a/app/ThemeViewController.m
+++ b/app/ThemeViewController.m
@@ -68,20 +68,26 @@ struct PaletteTextFields {
     self.navigationItem.title = self.theme.name;
     
     _nameTextField = [self detailTextFieldWithText:_theme.name monospaced: NO];
+    _nameTextField.accessibilityLabel = @"Theme Name";
     _singlePaletteSwitch = [UISwitch new];
     _singlePaletteSwitch.on = self.theme.lightPalette == self.theme.darkPalette;
     [_singlePaletteSwitch addTarget:self action:@selector(singlePaletteChanged:) forControlEvents:UIControlEventValueChanged];
     
     for (int i = 0; i < sizeof(_paletteTextFields) / sizeof(*_paletteTextFields); ++i) {
         Palette *palette = i ? self.theme.darkPalette : self.theme.lightPalette;
+        NSString *prefix = i ? @"Dark Palette " : @"Light Palette ";
         _paletteTextFields[i].foregroundTextField = [self detailTextFieldWithText:palette.foregroundColor monospaced:YES];
+        _paletteTextFields[i].foregroundTextField.accessibilityLabel = [prefix stringByAppendingString:@"Foreground Color"];
         _paletteTextFields[i].backgroundTextField = [self detailTextFieldWithText:palette.backgroundColor monospaced:YES];
+        _paletteTextFields[i].backgroundTextField.accessibilityLabel = [prefix stringByAppendingString:@"Background Color"];
         _paletteTextFields[i].cursorTextField = [self detailTextFieldWithText:palette.cursorColor monospaced:YES];
+        _paletteTextFields[i].cursorTextField.accessibilityLabel = [prefix stringByAppendingString:@"Cursor Color"];
         NSMutableArray<UITextField *> *textFields = [NSMutableArray new];
         for (int j = 0; j < COLORS; ++j) {
             UITextField *textField = [self detailTextFieldWithText:palette.colorPaletteOverrides ? palette.colorPaletteOverrides[j] : nil monospaced: YES];
             textField.autocorrectionType = UITextAutocorrectionTypeNo;
             textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+            textField.accessibilityLabel = [prefix stringByAppendingString:colorNames[j]];
             [textFields addObject:textField];
         }
         _paletteTextFields[i].colorTextFields = textFields;


### PR DESCRIPTION
What: Added explicit `accessibilityLabel`s to `UITextField`s in settings and theme views. Added `UIAccessibilityTraitButton` to actionable static table view cells.
Why: Screen reader users lacked context for text fields and were unaware that certain table view cells were interactive buttons.
Accessibility: VoiceOver now announces proper labels for text fields and button traits for interactive cells.

---
*PR created automatically by Jules for task [16044542831871642448](https://jules.google.com/task/16044542831871642448) started by @emkey1*