### PR TITLE
⚡ Bolt: Optimize read_proc_line string length calculation

### DIFF
--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,14 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    // Bolt Optimization: Cache strlen(name) outside the loop to prevent O(N) recalculation
+    // on every iteration while reading the /proc file.
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Cached the length of `name` in `read_proc_line` outside the loop.
🎯 Why: To prevent redundant O(N) recalculations of `strlen(name)` on every iteration while reading from `/proc` files.
📊 Impact: Reduces CPU cycles spent computing the string length repeatedly during `/proc` file parsing, which is frequently used to get system usage stats.
🔬 Measurement: Syntax checking `platform/linux.c` and running E2E test suite to ensure no breakage.

---
*PR created automatically by Jules for task [8309147949925277206](https://jules.google.com/task/8309147949925277206) started by @emkey1*