### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in realfs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-04-03 - Buffer Overflow in realfs_readdir Directory Name Copy
+**Vulnerability:** Unbounded `strcpy` used to copy host directory entry names into the fixed-size `entry->name` buffer of `struct dir_entry` in `fs/real.c`.
+**Learning:** Data crossing the boundary from the host OS into the emulator (like host directory names) must be explicitly bounds-checked, as host limits may exceed emulator limits, leading to buffer overflows.
+**Prevention:** Always use `strncpy` and manually ensure null-termination when copying host-provided strings into fixed-size emulator structures.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded `strcpy` in `fs/real.c` copies host directory entry names into the fixed-size `struct dir_entry` buffer. If a host system filename exceeds `NAME_MAX`, it causes a buffer overflow.
🎯 Impact: Potential memory corruption, application crash, or arbitrary code execution if an attacker can control host directory names accessed by the emulator.
🔧 Fix: Replaced `strcpy` with `strncpy` and explicitly added null-termination to safely truncate oversized host filenames.
✅ Verification: Syntax verified, E2E test suite executed as part of the verification process.

---
*PR created automatically by Jules for task [14284679522125433889](https://jules.google.com/task/14284679522125433889) started by @emkey1*