### PR TITLE
🛡️ Sentinel: [HIGH] Fix off-by-one buffer overflow in procfs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2024-04-04 - Off-by-one Stack Buffer Overflow in procfs path handling
+**Vulnerability:** Fixed-size buffers `char entry_name[MAX_NAME];` and `char component[MAX_NAME];` in `fs/proc.c` lacked space for a null terminator, potentially causing off-by-one stack buffer overflows when handling maximum length names.
+**Learning:** Arrays intended to store up to `MAX_NAME` characters must always be allocated with `MAX_NAME + 1` to accommodate the null terminator.
+**Prevention:** Audit all stack-allocated path buffers to ensure they use `MAX_NAME + 1`. Use bounded string operations for copying names.

--- a/fs/proc.c
+++ b/fs/proc.c
@@ -17,7 +17,7 @@ static int proc_lookup(const char *path, struct proc_entry *entry) {
 
         unsigned long index = 0;
         struct proc_entry next_entry = {0};
-        char entry_name[MAX_NAME];
+        char entry_name[MAX_NAME + 1];
         while (proc_dir_read(entry, &index, &next_entry)) {
             // tack on some dynamically generated attributes
             if (next_entry.meta->parent == NULL)
@@ -63,7 +63,7 @@ static int proc_getpath(struct fd *fd, char *buf) {
     p[0] = '\0';
     struct proc_entry entry = fd->proc.entry;
     while (entry.meta != &proc_root) {
-        char component[MAX_NAME];
+        char component[MAX_NAME + 1];
         proc_entry_getname(&entry, component);
         size_t component_len = strlen(component) + 1; // plus one for the slash
         p -= component_len;


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: Missing space for null terminator in fixed-size buffers `entry_name` and `component` inside `fs/proc.c` caused off-by-one stack buffer overflow.\n🎯 Impact: Stack buffer overflow and potential memory corruption.\n🔧 Fix: Increased array size to `MAX_NAME + 1` to accommodate the null terminator.\n✅ Verification: Syntax checked and tests ran.

---
*PR created automatically by Jules for task [2329527737429183976](https://jules.google.com/task/2329527737429183976) started by @emkey1*