### PR TITLE
⚡ Bolt: Optimize getdents dirent filling performance

### DIFF
--- a/fs/dir.c
+++ b/fs/dir.c
@@ -35,22 +35,20 @@ struct linux_dirent64_ {
     char name[];
 } __attribute__((packed));
 
-size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent_, name) + namelen + 1; // name, null terminator, type
     memcpy(dirent->name, name, namelen);
     *((char *) dirent + dirent->reclen - 1) = type;
     return dirent->reclen;
 }
 
-size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent64_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent64_, name) + namelen; // name, null terminator
     dirent->type = type;
     memcpy(dirent->name, name, namelen);
@@ -58,7 +56,7 @@ size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char 
 }
 
 int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
-        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int)) {
+        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, size_t, int)) {
     STRACE("getdents(%d, %#x, %#x)", f, dirents, count);
     struct fd *fd = f_get(f);
     if (fd == NULL)
@@ -85,14 +83,17 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         if (err == 0)
             break;
 
-        size_t max_reclen = sizeof(struct linux_dirent64_) + strlen(entry.name) + 4;
+        // Bolt Optimization: Calculate string length once here to prevent
+        // redundant O(N) traversals inside the fill_dirent callbacks.
+        size_t name_len = strlen(entry.name);
+        size_t max_reclen = sizeof(struct linux_dirent64_) + name_len + 4;
         char dirent_data[max_reclen];
         dirent_data[0] = 0;
         ino_t inode = entry.inode;
         off_t_ offset = fd_telldir(fd);
         const char *name = entry.name;
         int type = 0;
-        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type);
+        size_t reclen = fill_dirent(dirent_data, inode, offset, name, name_len + 1, type);
         if (printed < 20) {
             STRACE(" {inode=%d, offset=%d, name=%s, type=%d, reclen=%d}",
                     inode, offset, name, type, reclen);


### PR DESCRIPTION
💡 What: Modified `sys_getdents_common` and `fill_dirent` callbacks to pass the pre-calculated string length instead of recalculating it.
🎯 Why: To prevent redundant O(N) string traversals in VFS directory iteration which was unnecessarily degrading performance on large directories.
📊 Impact: O(1) string length assignment inside fill_dirent, improving `sys_getdents` performance on large directories.
🔬 Measurement: E2E test suite passing confirms behavior is preserved. Benchmarking `getdents` system call over large directories would show reduced CPU cycles per entry.

---
*PR created automatically by Jules for task [4435988032411351728](https://jules.google.com/task/4435988032411351728) started by @emkey1*