### PR TITLE
🎨 Palette: Add accessibility hint to Progress Report cancel button

### DIFF
--- a/app/ProgressReportViewController.m
+++ b/app/ProgressReportViewController.m
@@ -28,6 +28,7 @@
 
 - (void)viewDidLoad {
     self.titleLabel.text = self.title;
+    self.cancelButton.accessibilityHint = @"Cancels the current operation.";
     if (@available(iOS 13, *)) {
         self.backdrop.effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemMaterial];
     }


### PR DESCRIPTION
💡 What: Added an accessibility hint to the Cancel button in the Progress Report popup.
🎯 Why: Screen reader users need to know exactly what the cancel button will do in the context of a progress report.
📸 Before/After: N/A
♿ Accessibility: Screen reader users will hear "Cancels the current operation" as a hint when focused on the Cancel button.

---
*PR created automatically by Jules for task [12655510292368098826](https://jules.google.com/task/12655510292368098826) started by @emkey1*