### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in realfs directory reading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2026-04-05 - Buffer Overflow in Host Directory Reading
+**Vulnerability:** Unbounded string copy (`strcpy`) in `fs/real.c` when copying host filesystem directory names (`dirent->d_name`) into the emulator's fixed-size `dir_entry` struct (`entry->name`). Host filesystems may support longer file names than the emulator's `NAME_MAX`.
+**Learning:** Data crossing the boundary from the host OS into the emulator must always be explicitly bounds-checked, as host limits may exceed emulator limits and cause stack or heap buffer overflows.
+**Prevention:** Always use bounded string functions (`strncpy` with explicit null termination) when transferring data from external sources (like host APIs) into internal fixed-size structures.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded string copy (`strcpy`) in `fs/real.c` when reading directory entries from the host filesystem. If the host returns a directory entry name longer than `NAME_MAX` (255 characters), it overflows the `entry->name` buffer.
🎯 Impact: Potential buffer overflow leading to memory corruption or crashes when interacting with host filesystems that contain unusually long file names.
🔧 Fix: Replaced `strcpy` with `strncpy` bounded by `sizeof(entry->name) - 1` and added explicit null termination to ensure memory safety.
✅ Verification: Ran `gcc -fsyntax-only` on the modified file and executed the E2E test suite.

---
*PR created automatically by Jules for task [13447827006490161835](https://jules.google.com/task/13447827006490161835) started by @emkey1*