### PR TITLE
⚡ Bolt: Replace O(N) strlen with O(1) pointer arithmetic in tmpfs_getpath

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2024-05-27 - O(1) string length calculation for backwards construction
+**Learning:** In C string manipulation, when strings are constructed backwards from the end of a known buffer (e.g., `buf + MAX_PATH - 1` in `fs/tmp.c`), avoid `strlen()` which causes an unnecessary O(N) traversal.
+**Action:** Use pointer arithmetic `(buf + MAX_PATH - 1) - p` to calculate the exact string length in O(1) time.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -590,7 +590,7 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    memmove(buf, p, (buf + MAX_PATH - 1) - p + 1);
     return 0;
 }
 


### PR DESCRIPTION
💡 What: Replaced `strlen(p)` with `(buf + MAX_PATH - 1) - p` in `tmpfs_getpath` in `fs/tmp.c`.
🎯 Why: The string is constructed backwards starting from the end of `buf`. Instead of doing an O(N) traversal with `strlen()`, we can calculate the exact length in O(1) time using pointer arithmetic since we know both the start (`p`) and end (`buf + MAX_PATH - 1`) pointers.
📊 Impact: Removes an O(N) traversal during `tmpfs_getpath`, providing a minor but measurable reduction in CPU cycles during path resolution for tmpfs file descriptors.
🔬 Measurement: The correctness can be verified via the passing E2E test suite. Performance impact is verifiable via microbenchmarking `tmpfs_getpath` execution time.

---
*PR created automatically by Jules for task [8237974690805578404](https://jules.google.com/task/8237974690805578404) started by @emkey1*