### PR TITLE
🎨 Palette: Add accessibility label to filesystem name field

### DIFF
--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -142,6 +142,7 @@
     self.navigationItem.title = self.rootName;
     self.nameField.enabled = !self.isDefaultRoot;
     self.nameField.clearButtonMode = self.isDefaultRoot ? UITextFieldViewModeNever : UITextFieldViewModeAlways;
+    self.nameField.accessibilityLabel = @"Filesystem Name";
     self.deleteLabel.enabled = !self.isDefaultRoot;
     self.deleteCell.selectionStyle = !self.isDefaultRoot ? UITableViewCellSelectionStyleDefault : UITableViewCellSelectionStyleNone;
     [self.tableView reloadData];


### PR DESCRIPTION
💡 What: Added an explicit accessibility label to the filesystem name text field.
🎯 Why: The static cell text label ("Name") is not automatically associated with the embedded text field in the Storyboard, causing screen readers to announce the field without context.
📸 Before/After: N/A (non-visual change).
♿ Accessibility: VoiceOver now announces "Filesystem Name" instead of just the content or "Text field".

---
*PR created automatically by Jules for task [17368612600917032426](https://jules.google.com/task/17368612600917032426) started by @emkey1*