### PR TITLE
⚡ Bolt: Optimize getdents by avoiding redundant strlen calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2024-04-06 - Avoid redundant O(N) string calculations inside loop callbacks
+**Learning:** In hot loops like directory entry fetching, computing string length (`strlen`) in the caller and passing it as an argument avoids redundant O(N) string recalculations inside dynamically dispatched callback functions.
+**Action:** Always compute derived parameters like string lengths at the highest possible scope and pass them into inner loops or callbacks instead of recalculating them multiple times.

--- a/fs/dir.c
+++ b/fs/dir.c
@@ -35,22 +35,20 @@ struct linux_dirent64_ {
     char name[];
 } __attribute__((packed));
 
-size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent_, name) + namelen + 1; // name, null terminator, type
     memcpy(dirent->name, name, namelen);
     *((char *) dirent + dirent->reclen - 1) = type;
     return dirent->reclen;
 }
 
-size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent64_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent64_, name) + namelen; // name, null terminator
     dirent->type = type;
     memcpy(dirent->name, name, namelen);
@@ -58,7 +56,7 @@ size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char 
 }
 
 int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
-        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int)) {
+        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, size_t, int)) {
     STRACE("getdents(%d, %#x, %#x)", f, dirents, count);
     struct fd *fd = f_get(f);
     if (fd == NULL)
@@ -85,14 +83,15 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         if (err == 0)
             break;
 
-        size_t max_reclen = sizeof(struct linux_dirent64_) + strlen(entry.name) + 4;
+        size_t namelen = strlen(entry.name) + 1; // Include null terminator
+        size_t max_reclen = sizeof(struct linux_dirent64_) + namelen + 3;
         char dirent_data[max_reclen];
         dirent_data[0] = 0;
         ino_t inode = entry.inode;
         off_t_ offset = fd_telldir(fd);
         const char *name = entry.name;
         int type = 0;
-        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type);
+        size_t reclen = fill_dirent(dirent_data, inode, offset, name, namelen, type);
         if (printed < 20) {
             STRACE(" {inode=%d, offset=%d, name=%s, type=%d, reclen=%d}",
                     inode, offset, name, type, reclen);


### PR DESCRIPTION
💡 What: Updated `fill_dirent_32` and `fill_dirent_64` to accept `namelen` as a parameter and computed `strlen(entry.name)` once in `sys_getdents_common`.
🎯 Why: In `fs/dir.c`, `sys_getdents_common` previously called `strlen(entry.name)` to compute maximum record length, and then passed `name` to the `fill_dirent` callbacks, which called `strlen(name)` again, causing redundant O(N) string traversals for every single directory entry.
📊 Impact: Reduces redundant string traversals in `sys_getdents_common`, improving performance when listing directories containing many files.
🔬 Measurement: Verify by running directory listing commands (like `ls`) on large directories in the emulator.

---
*PR created automatically by Jules for task [3650394628592413673](https://jules.google.com/task/3650394628592413673) started by @emkey1*