### PR TITLE
🎨 Palette: Expose settings update badge to VoiceOver

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-27 - Overriding accessibilityTraits Getter Destructively
 **Learning:** When creating custom accessible controls by subclassing existing ones, completely overriding the `accessibilityTraits` getter (e.g., `return UIAccessibilityTraitAdjustable;`) destructively removes inherent superclass traits (such as `UIAccessibilityTraitButton`).
 **Action:** Always use a bitwise OR with `[super accessibilityTraits]` (e.g., `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`) when overriding the `accessibilityTraits` getter to preserve necessary inherited traits.
+
+## 2026-04-06 - Exposing Visual Badge State to Screen Readers
+**Learning:** Visual badges (like red dots indicating updates) are completely invisible to VoiceOver users unless explicitly exposed. Modifying a button's `accessibilityValue` to reflect the badge state ensures screen reader users receive the same notifications as sighted users without cluttering the main label.
+**Action:** Whenever implementing a visual badge on a control, always update the control's `accessibilityValue` to announce the badge's presence and meaning.

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -560,6 +560,10 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+
+    NSString *value = showBadge ? @"Update available" : nil;
+    self.infoButton.accessibilityValue = value;
+    self.floatingSettingsButton.accessibilityValue = value;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
💡 What: Added an `accessibilityValue` to the settings buttons that is conditionally populated when an update badge is visible.
🎯 Why: Visual badges, like red notification dots, are invisible to screen reader users. Updating the `accessibilityValue` to "Update available" ensures visually impaired users are properly notified of available updates.
📸 Before/After: Visuals are unchanged. VoiceOver will now append "Update available" when the update badge is present on the Settings button.
♿ Accessibility: Ensures VoiceOver users receive equitable notification of available updates via the `accessibilityValue` attribute.

---
*PR created automatically by Jules for task [16083157210844991732](https://jules.google.com/task/16083157210844991732) started by @emkey1*