### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix potential buffer overflow in realfs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-03-27 - Buffer Overflow in Host Filesystem Interface
+**Vulnerability:** Unbounded string copy (`strcpy`) writing to a fixed-size char array (`char name[NAME_MAX + 1]`) in `fs/real.c` (`realfs_readdir`).
+**Learning:** Data crossing the boundary from the host OS into the emulator (e.g., host filesystem directory names in `fs/real.c`) must be explicitly bounds-checked against internal emulator limits (like `NAME_MAX`), as host limits may exceed them and cause buffer overflows.
+**Prevention:** Always use `strncpy` and manually ensure null-termination for fixed-size string arrays in the kernel when handling data from external boundaries.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unbounded string copy (`strcpy`) writing a host directory entry name into a fixed-size emulator struct field (`entry->name`) in `fs/real.c`.
🎯 Impact: If the host filesystem provides a directory name longer than the emulator's `NAME_MAX`, it could overflow the `entry->name` buffer, potentially corrupting adjacent memory and leading to unexpected behavior or crashes.
🔧 Fix: Replaced `strcpy` with `strncpy`, limiting the copy to `sizeof(entry->name) - 1`, and explicitly added null-termination.
✅ Verification: Syntax validation via `gcc -fsyntax-only fs/real.c -I. -D_GNU_SOURCE` and E2E test suite via `./tests/e2e/e2e.bash`.

---
*PR created automatically by Jules for task [11919484045403716447](https://jules.google.com/task/11919484045403716447) started by @emkey1*