### PR TITLE
⚡ Bolt: Hoist loop-invariant strlen calls in read_proc_line

### DIFF
--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,13 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    // Cache strlen to avoid O(N) recalculations on every line read from /proc
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
- **What:** Hoist the calculation of `strlen(name)` outside the file-reading `do-while` loop in `read_proc_line` within `platform/linux.c`. Added comment explaining the optimization.
- **Why:** In `read_proc_line`, `strlen(name)` was evaluated on every iteration while scanning lines from files like `/proc/stat`. Since `name` is constant during the loop, this caused redundant O(N) recalculations for every line read.
- **Impact:** Reduces CPU overhead during `/proc` file parsing by eliminating O(N) string traversals per line, achieving an O(1) condition check after the initial O(N) calculation.
- **Measurement:** Performance can be measured by profiling the execution time of repeated reads of `/proc/stat` or similar operations calling `read_proc_line`, expecting a decrease in string-related overhead.

---
*PR created automatically by Jules for task [3595220729205076625](https://jules.google.com/task/3595220729205076625) started by @emkey1*