### PR TITLE
🎨 Palette: Improve accessibility for root filesystem actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-27 - Overriding accessibilityTraits Getter Destructively
 **Learning:** When creating custom accessible controls by subclassing existing ones, completely overriding the `accessibilityTraits` getter (e.g., `return UIAccessibilityTraitAdjustable;`) destructively removes inherent superclass traits (such as `UIAccessibilityTraitButton`).
 **Action:** Always use a bitwise OR with `[super accessibilityTraits]` (e.g., `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`) when overriding the `accessibilityTraits` getter to preserve necessary inherited traits.
+
+## 2024-05-28 - Action Cells and Text Field Accessibility
+**Learning:** Static `UITableViewCell` instances used as action buttons do not inherently possess `UIAccessibilityTraitButton`, and screen readers will not announce them as buttons. In addition, standalone `UITextField`s in cells require explicit `accessibilityLabel`s for robust context.
+**Action:** Always explicitly add `UIAccessibilityTraitButton` (e.g., via `tableView:willDisplayCell:forRowAtIndexPath:`) to action cells, set `accessibilityLabel`s for `UITextField`s, and manage traits for disabled states (e.g., `UIAccessibilityTraitNotEnabled`).

--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -72,10 +72,16 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    BOOL isDefault = [Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot];
+    if (isDefault)
         ident = @"Default Root";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+    if (isDefault) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 
@@ -133,6 +139,11 @@
 
 @implementation RootDetailViewController
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.nameField.accessibilityLabel = @"Name";
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     self.nameField.text = self.rootName;
     [self update];
@@ -166,6 +177,21 @@
 
 - (BOOL)isDefaultRoot {
     return [self.rootName isEqualToString:Roots.instance.defaultRoot];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (cell == self.deleteCell) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+        if (self.isDefaultRoot) {
+            cell.accessibilityTraits |= UIAccessibilityTraitNotEnabled;
+        } else {
+            cell.accessibilityTraits &= ~UIAccessibilityTraitNotEnabled;
+        }
+    } else if ((indexPath.section == 0 && indexPath.row == 1) ||
+               (indexPath.section == 0 && indexPath.row == 2) ||
+               (indexPath.section == 1 && indexPath.row == 0)) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+    }
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section {


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` to the default root cell in `RootsTableViewController`, and added `UIAccessibilityTraitButton`, `UIAccessibilityTraitNotEnabled`, and `accessibilityLabel`s for elements in `RootDetailViewController`.
🎯 Why: To provide accurate and clear screen reader context for static `UITableViewCell` instances used as action buttons, and explicitly label text fields.
📸 Before/After: Visuals are unchanged; accessibility traits are correctly updated for VoiceOver.
♿ Accessibility: Improved VoiceOver navigation and state announcement for root filesystem actions.

---
*PR created automatically by Jules for task [13667095500086703705](https://jules.google.com/task/13667095500086703705) started by @emkey1*