### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in realfs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2026-03-27 - Buffer Overflow in realfs_readdir
+**Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[NAME_MAX + 1]`) in `fs/real.c` when reading directory entries from the host filesystem.
+**Learning:** Data crossing the boundary from the host OS into the emulator (e.g., host filesystem directory names) must be explicitly bounds-checked against internal emulator limits (like `NAME_MAX`), as host limits may exceed them and cause buffer overflows.
+**Prevention:** Always use `strlcpy` for safe, null-terminated string copies into fixed-size buffers, especially when handling data from the host filesystem or other external boundaries.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,7 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strlcpy(entry->name, dirent->d_name, sizeof(entry->name));
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `fs/real.c` used `strcpy` to copy directory names from the host filesystem into the emulator's `dir_entry` structure without bounds checking.
🎯 Impact: If the host filesystem contained a directory entry with a name longer than the emulator's `NAME_MAX`, it would cause a buffer overflow, potentially leading to arbitrary code execution or a Denial of Service.
🔧 Fix: Replaced `strcpy` with `strlcpy` to enforce bounds checking against `sizeof(entry->name)`, ensuring the string is properly truncated and null-terminated if it exceeds the limit.
✅ Verification: Ran `gcc -fsyntax-only fs/real.c -I. -D_GNU_SOURCE` to ensure no syntax errors. Ran `./tests/e2e/e2e.bash` to verify no regressions.

---
*PR created automatically by Jules for task [10148621393564792820](https://jules.google.com/task/10148621393564792820) started by @emkey1*