### PR TITLE
🎨 Palette: Add accessibility value for upgrade apk badge

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-27 - Overriding accessibilityTraits Getter Destructively
 **Learning:** When creating custom accessible controls by subclassing existing ones, completely overriding the `accessibilityTraits` getter (e.g., `return UIAccessibilityTraitAdjustable;`) destructively removes inherent superclass traits (such as `UIAccessibilityTraitButton`).
 **Action:** Always use a bitwise OR with `[super accessibilityTraits]` (e.g., `return [super accessibilityTraits] | UIAccessibilityTraitAdjustable;`) when overriding the `accessibilityTraits` getter to preserve necessary inherited traits.
+
+## 2024-05-28 - Exposing Visual Badges to Screen Readers
+**Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
+**Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.

--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -95,6 +95,7 @@
     self.upgradeApkCell.userInteractionEnabled = FsNeedsRepositoryUpdate();
     self.upgradeApkLabel.enabled = FsNeedsRepositoryUpdate();
     self.upgradeApkBadge.hidden = !FsNeedsRepositoryUpdate();
+    self.upgradeApkCell.accessibilityValue = FsNeedsRepositoryUpdate() ? @"Update available" : nil;
     [self.tableView reloadData];
 }
 


### PR DESCRIPTION
💡 What: Set accessibilityValue of upgradeApkCell to "Update available" when an update is present.
🎯 Why: Visual badges are invisible to VoiceOver. Exposing the badge state via accessibilityValue ensures screen reader users are aware of available updates without cluttering the main label.
📸 Before/After: N/A
♿ Accessibility: Added "Update available" accessibility value to the upgrade apk cell when the visual update badge is visible.

---
*PR created automatically by Jules for task [9988867253221106177](https://jules.google.com/task/9988867253221106177) started by @emkey1*