### PR TITLE
🎨 Palette: Add accessibility traits for default root selection

### DIFF
--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -107,6 +107,12 @@
         ident = @"Default Root";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+
+    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot]) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
*   **💡 What:** Added `UIAccessibilityTraitSelected` to the default root cell in `RootsTableViewController`.
*   **🎯 Why:** To clearly indicate to VoiceOver users which root filesystem is currently selected as the default.
*   **♿ Accessibility:** VoiceOver will now announce "Selected" when navigating to the default root.

---
*PR created automatically by Jules for task [15143208138584805949](https://jules.google.com/task/15143208138584805949) started by @emkey1*