### PR TITLE
⚡ Bolt: Optimize loop condition in read_proc_line

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2024-05-27 - Hoist loop-invariant strlen calls
+**Learning:** To prevent redundant O(N) recalculations during loop iterations (e.g., `while` loops reading from `/proc` files via `fgets`), hoist invariant `strlen()` calls on target strings outside the loop. (e.g., caching `strlen(name)` in `platform/linux.c`'s `read_proc_line`).
+**Action:** When performing string comparisons inside loops, calculate the string length once before the loop and reuse the cached length variable within the loop condition or body.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Cached the `strlen(name)` call outside the `do...while` loop in `read_proc_line`.
🎯 Why: `strlen(name)` was being called twice on every iteration of the loop, resulting in unnecessary O(N) recalculations for a loop-invariant string length.
📊 Impact: Reduces redundant O(N) string length computations, slightly speeding up `/proc` file parsing when multiple lines need to be read before finding a match.
🔬 Measurement: Verified by running the E2E tests and checking that `/proc` parsing still works as expected.

---
*PR created automatically by Jules for task [14458777609389656995](https://jules.google.com/task/14458777609389656995) started by @emkey1*