### PR TITLE
🎨 Palette: Expose settings badge state to screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Exposing Settings Badge State
+**Learning:** In the Terminal view, the visual settings badge (indicating an available update) was not exposed to screen readers.
+**Action:** Always update the `accessibilityValue` of buttons dynamically when adding visual indicators to ensure screen readers announce the state correctly.

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -653,6 +653,9 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+    NSString *accessibilityValue = showBadge ? @"Update available" : nil;
+    self.infoButton.accessibilityValue = accessibilityValue;
+    self.floatingSettingsButton.accessibilityValue = accessibilityValue;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
**💡 What:** Added a dynamic `accessibilityValue` to the Settings buttons (`infoButton` and `floatingSettingsButton`) in the Terminal view.
**🎯 Why:** The visual red badge indicating an available repository update was previously invisible to VoiceOver users, denying them important state information from the main terminal screen.
**📸 Before/After:** N/A (Non-visual change)
**♿ Accessibility:** VoiceOver will now announce "Settings, Button, Update available" (or similar) when a repository update is pending, improving feature discoverability.

---
*PR created automatically by Jules for task [6158776808714935418](https://jules.google.com/task/6158776808714935418) started by @emkey1*