### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in string operations using strcpy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-03-27 - Buffer Overflow in Unsafe strcpy usages
+**Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size buffers like `resolved[MAX_PATH]` in `kernel/exec.c`, `parent` array in `kernel/inotify.c`, and `entry->name` in `fs/real.c` / `fs/aok.c`.
+**Learning:** Legacy system code uses unsafe `strcpy`, leaving the system prone to buffer overflows when external inputs exceed bounded constraints.
+**Prevention:** Replace all `strcpy` calls with boundary-aware functions like `strlcpy` and pass the exact bounds when writing to fixed-size array boundaries.

--- a/fs/aok.c
+++ b/fs/aok.c
@@ -276,7 +276,7 @@ static int aokfs_readdir(struct fd *fd, struct dir_entry *entry) {
     }
 
     entry->inode = aokfs_node_inode(child);
-    strcpy(entry->name, aokfs_node_basename(child));
+    strlcpy(entry->name, aokfs_node_basename(child), sizeof(entry->name));
     return 1;
 }
 

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,7 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strlcpy(entry->name, dirent->d_name, sizeof(entry->name));
     return 1;
 }
 

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -877,7 +877,7 @@ ssize_t sys_execveat(fd_t dirfd, addr_t filename_addr, addr_t argv_addr, addr_t 
         if (err < 0)
             goto out_free_args;
     } else if (filename[0] == '/') {
-        strcpy(resolved, filename);
+        strlcpy(resolved, filename, sizeof(resolved));
     } else {
         struct fd *at = (dirfd == AT_FDCWD_) ? AT_PWD : f_get(dirfd);
         if (at == NULL) {

--- a/kernel/inotify.c
+++ b/kernel/inotify.c
@@ -96,12 +96,12 @@ static dword_t inotify_name_len(const char *name) {
 static void inotify_parent_and_name(const char *path, char *parent, const char **name_out) {
     const char *slash = strrchr(path, '/');
     if (slash == NULL) {
-        strcpy(parent, "/");
+        strlcpy(parent, "/", MAX_PATH);
         *name_out = path;
         return;
     }
     if (slash == path) {
-        strcpy(parent, "/");
+        strlcpy(parent, "/", MAX_PATH);
         *name_out = slash + 1;
         return;
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded `strcpy` copies data to fixed-size buffers, which causes buffer overflow if external input is excessively long.
🎯 Impact: Arbitrary code execution or system crash.
🔧 Fix: Replace `strcpy` with bounded `strlcpy` on strings in `kernel/exec.c`, `kernel/inotify.c`, `fs/real.c`, and `fs/aok.c`.
✅ Verification: Ran unit tests and the E2E test suite.

---
*PR created automatically by Jules for task [14349114185889005600](https://jules.google.com/task/14349114185889005600) started by @emkey1*