### PR TITLE
🎨 Palette: Add accessibility trait for selected dock buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Active States on Custom iOS Controls
+**Learning:** Returning strings like `"Show"` or `"Focus"` for `accessibilityValue` on custom UI controls doesn't fully communicate their selection state to VoiceOver users. When a custom control indicates an active or frontmost state visually, it must also programmatically communicate this selection state.
+**Action:** Use standard bitwise operations to add `UIAccessibilityTraitSelected` to `accessibilityTraits` when a custom control (like a dock tile button) is active or selected, and properly clear it (`&= ~UIAccessibilityTraitSelected`) when inactive.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -958,6 +958,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     button.backgroundColor = fillColor;
     button.layer.borderColor = borderColor.CGColor;
     button.accessibilityValue = state;
+    if (active) {
+        button.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (UIStackView *)workspaceToolLauncherRowWithTitle:(NSString *)title


### PR DESCRIPTION
What: Added `UIAccessibilityTraitSelected` to dock tile buttons in `WorkspaceViewController` when they are active.
Why: VoiceOver users need to know which dock items are currently active or selected, rather than relying solely on the visual background/border color changes.
Before/After: N/A (no visual changes).
Accessibility: Adds `UIAccessibilityTraitSelected` to active workspace dock buttons so VoiceOver will correctly announce them as selected.

---
*PR created automatically by Jules for task [9197670004114434953](https://jules.google.com/task/9197670004114434953) started by @emkey1*