### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix kernel state overwrite in file locking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-04-12 - Kernel State Overwrite via Reversed strncpy in flock
+**Vulnerability:** In `fs/lock.c` (`flock_from_file_lock`), the `strncpy` copy direction was reversed (`strncpy(lock->comm, flock->comm, 16);`), overwriting the kernel file lock state (`lock->comm`) with uninitialized user-supplied memory from `flock->comm`.
+**Learning:** When populating user-facing structures from kernel data, it is crucial to ensure the copy direction is strictly kernel-to-user. A simple argument swap in string copy functions can lead to memory corruption or arbitrary kernel state modification.
+**Prevention:** Always verify that the destination argument is the user structure and the source argument is the kernel structure. Use static analysis or parameter naming conventions to make copy directions explicit.

--- a/fs/lock.c
+++ b/fs/lock.c
@@ -197,7 +197,7 @@ static int flock_from_file_lock(struct file_lock *lock, struct flock_ *flock) {
     else
         flock->len = 0;
     flock->pid = lock->pid;
-    strncpy(lock->comm, flock->comm, 16);
+    strncpy(flock->comm, lock->comm, sizeof(flock->comm));
     return 0;
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: In `fs/lock.c` (`flock_from_file_lock`), the `strncpy` copy direction was reversed, overwriting the kernel file lock state (`lock->comm`) with uninitialized user-supplied memory from `flock->comm`.
🎯 Impact: An attacker could potentially corrupt kernel memory or manipulate file lock tracking mechanisms by passing crafted data in the `flock` structure, leading to denial of service or sandbox escapes.
🔧 Fix: Corrected the `strncpy` arguments to copy from the kernel lock structure (`lock->comm`) to the user flock structure (`flock->comm`) using `sizeof(flock->comm)` for bounded safety.
✅ Verification: Ran the E2E test suite to ensure the system remains stable and no regressions were introduced.

---
*PR created automatically by Jules for task [17614520963069473644](https://jules.google.com/task/17614520963069473644) started by @emkey1*