### PR TITLE
⚡ Bolt: Optimize string length calculation in getpath functions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-04-12 - Optimize backward string construction length calculation
+**Learning:** In VFS `getpath` implementations (e.g., `tmpfs_getpath` in `fs/tmp.c`), paths are constructed by prepending components starting from the end of a fixed-size buffer (`buf + MAX_PATH - 1`). Using `strlen(p)` to determine the final length before copying it out causes an unnecessary O(N) string traversal when the exact length is already mathematically known.
+**Action:** When a string is constructed backwards from a known end pointer, calculate its length in O(1) time using pointer arithmetic (e.g., `buf + MAX_PATH - p`) instead of `strlen(p)`.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -590,7 +590,8 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    // Optimization: Calculate length via pointer arithmetic instead of O(N) strlen
+    memmove(buf, p, buf + MAX_PATH - p);
     return 0;
 }
 


### PR DESCRIPTION
💡 What: Replaced `strlen(p)` with O(1) pointer arithmetic `(buf + MAX_PATH - 1) - p` (simplified implicitly to `buf + MAX_PATH - p`) in `tmpfs_getpath` (`fs/tmp.c`).
🎯 Why: The string is built backward from the end of a fixed-size buffer (`buf + MAX_PATH - 1`). Using `strlen(p)` when the final string length is already known implicitly causes an unnecessary O(N) string traversal. Pointer arithmetic computes the length in O(1).
📊 Impact: Eliminates an O(N) traversal per `tmpfs_getpath` call, improving VFS path resolution performance.
🔬 Measurement: Code review and syntax verification. E2E test suite execution verified no regressions in the sandboxed environment constraints.

---
*PR created automatically by Jules for task [3029607352003266720](https://jules.google.com/task/3029607352003266720) started by @emkey1*