### PR TITLE
🎨 Palette: Expose settings badge updates to VoiceOver

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -809,6 +809,10 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+
+    NSString *badgeValue = showBadge ? @"Update available" : nil;
+    self.infoButton.accessibilityValue = badgeValue;
+    self.floatingSettingsButton.accessibilityValue = badgeValue;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
- 💡 What: Added `accessibilityValue` updates to the settings buttons (`infoButton` and `floatingSettingsButton`) based on the visibility of the settings badge.
- 🎯 Why: Visual indicators like the red settings badge are invisible to screen readers unless programmatically exposed. This change ensures VoiceOver users are aware of available updates without cluttering the main `accessibilityLabel`.
- 📸 Before/After: Visual badge state was previously unannounced to VoiceOver. Now, VoiceOver announces "Update available" when the badge is present.
- ♿ Accessibility: Improved screen reader context for settings buttons by dynamically updating their `accessibilityValue` to reflect the badge state.

---
*PR created automatically by Jules for task [15326853077184952701](https://jules.google.com/task/15326853077184952701) started by @emkey1*