### PR TITLE
⚡ Bolt: Optimize read_proc_line by hoisting strlen

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2026-03-25 - Hoist strlen outside of loops
+**Learning:** In `platform/linux.c`, `read_proc_line` calls `strlen(name)` twice within a `do...while` loop that reads lines from a `/proc` file. This causes unnecessary O(N) recalculations for a loop-invariant string on every iteration.
+**Action:** When repeatedly checking prefixes or strings against lines in a file or stream, always hoist the `strlen()` calculation outside the loop and reuse the cached length.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,13 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    // Bolt: Hoist strlen(name) outside the loop to avoid O(N) recalculation on every iteration
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Hoisted the `strlen(name)` calculation outside the `do...while` loop in `read_proc_line` (`platform/linux.c`).
🎯 Why: The original implementation evaluated `strlen(name)` twice on every loop iteration while reading lines from `/proc` files. Since `name` is loop-invariant, this caused redundant O(N) string length recalculations.
📊 Impact: Reduces CPU overhead and O(N) redundant string traversals during `/proc` file parsing, particularly when reading large proc files.
🔬 Measurement: Verify by observing the same successful parsing of `/proc` files, with `read_proc_line` executing fewer CPU cycles.

---
*PR created automatically by Jules for task [4166923542151477740](https://jules.google.com/task/4166923542151477740) started by @emkey1*