### PR TITLE
⚡ Bolt: Hoist strlen() out of read_proc_line loop in platform/linux.c

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2024-05-27 - Redundant string operations in file reading loops
+**Learning:** Calling `strlen()` repeatedly inside loops that read lines from files (e.g., parsing `/proc` files via `fgets` in `platform/linux.c`) causes unnecessary O(N) recalculations for target strings whose lengths do not change.
+**Action:** When searching for specific lines in file reading loops, hoist loop-invariant `strlen()` calls on target strings outside the loop.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
**What**: Hoisted the `strlen(name)` calculation outside the `do-while` loop in `read_proc_line` within `platform/linux.c`.
**Why**: Inside `read_proc_line`, `strlen(name)` was previously being recalculated twice per iteration while scanning through lines from `/proc` files using `fgets()`. Since `name` does not change across iterations, recalculating its length is an unnecessary O(N) operation per line.
**Impact**: Eliminates two redundant string length recalculations per loop iteration during `/proc` file parsing, reducing CPU overhead during system monitoring tasks.
**Measurement**: Verified by ensuring the E2E test suite continues to run identically and checking that the target strings correctly match without regressions in `/proc` parsing.

---
*PR created automatically by Jules for task [18364333732355657417](https://jules.google.com/task/18364333732355657417) started by @emkey1*