### PR TITLE
🎨 Palette: Improve accessibility for action cells and text fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-29 - UITableViewCell static actions accessibility
+**Learning:** In iOS UI development within this codebase, static `UITableViewCell`s used as actions do not inherently possess `UIAccessibilityTraitButton`. They are announced merely as elements without indicating they are actionable buttons.
+**Action:** Always explicitly add this trait (e.g., via `tableView:willDisplayCell:forRowAtIndexPath:`) using `|= UIAccessibilityTraitButton` and assign explicit `accessibilityLabel`s to `UITextField`s inside cells to ensure robust screen reader context.

--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -238,7 +238,9 @@ UIViewController *ISHCreateDiagnosticsViewController(void) {
     self.initialWindowCell.textLabel.text = @"Startup Mode";
     self.initialWindowCell.detailTextLabel.text = [self _initialWindowTitle];
     self.launchCommandField.text = [UserPreferences.shared.launchCommand componentsJoinedByString:@" "];
+    self.launchCommandField.accessibilityLabel = @"Launch Command";
     self.bootCommandField.text = [UserPreferences.shared.bootCommand componentsJoinedByString:@" "];
+    self.bootCommandField.accessibilityLabel = @"Boot Command";
 
     self.upgradeApkCell.userInteractionEnabled = FsNeedsRepositoryUpdate();
     self.upgradeApkLabel.enabled = FsNeedsRepositoryUpdate();
@@ -271,6 +273,12 @@ UIViewController *ISHCreateDiagnosticsViewController(void) {
         iosfs_clear_all_bookmarks();
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (cell == self.sendFeedback || cell == self.diagnosticsCell || cell == self.initialWindowCell || cell == self.openGithub || cell == self.openDiscord || cell == self.exportContainerCell || cell == self.resetMountsCell) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+    }
 }
 
 - (NSString *)_initialWindowPreferenceValue {


### PR DESCRIPTION
**What:** Added `UIAccessibilityTraitButton` to static `UITableViewCell`s that act as buttons and assigned `accessibilityLabel`s to `UITextField`s in `AboutViewController`.

**Why:** VoiceOver users were not notified that these table cells were actionable buttons, and the command text fields lacked context. This ensures screen reader users can fully understand and interact with the About screen's configuration options.

**Before/After:** N/A (non-visual accessibility change)

**Accessibility:** Improved VoiceOver context and interaction by correctly exposing actionable cell elements and adding missing labels to text fields.

---
*PR created automatically by Jules for task [7728872989172190923](https://jules.google.com/task/7728872989172190923) started by @emkey1*