### PR TITLE
⚡ Bolt: Optimize read_proc_line string comparisons

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2026-04-15 - Optimize string length checks in proc loops
+**Learning:** In `platform/linux.c`, functions like `read_proc_line` recalculate `strlen(name)` repeatedly inside loop conditions. This forces an unnecessary O(N) re-evaluation for a string whose length is loop-invariant, which is especially costly when reading many lines from `/proc` files.
+**Action:** Always hoist loop-invariant `strlen()` calculations outside the loop to a dedicated length variable (e.g., `size_t name_len = strlen(name);`) and reuse it in loop conditions to ensure O(1) performance during traversal.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Cached `strlen(name)` outside the loop in `read_proc_line`.
🎯 Why: Re-evaluating `strlen(name)` twice on every iteration while reading a proc file results in redundant O(N) calculations and slows down file parsing.
📊 Impact: Improves parsing performance of proc files by preventing unnecessary re-evaluation of loop-invariant string lengths.
🔬 Measurement: Verify system metrics fetching behaves as expected with reduced CPU cycles.

---
*PR created automatically by Jules for task [18209436111166507925](https://jules.google.com/task/18209436111166507925) started by @emkey1*