### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow in readdir callbacks

### DIFF
--- a/fs/aok.c
+++ b/fs/aok.c
@@ -276,7 +276,8 @@ static int aokfs_readdir(struct fd *fd, struct dir_entry *entry) {
     }
 
     entry->inode = aokfs_node_inode(child);
-    strcpy(entry->name, aokfs_node_basename(child));
+    strncpy(entry->name, aokfs_node_basename(child), sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: `strcpy` into fixed-size buffer (`entry->name`) from potentially unbounded source (`dirent->d_name`, `aokfs_node_basename`)
- 🎯 Impact: Stack buffer overflow if directory name exceeds `NAME_MAX` limits (e.g. from host filesystem via `realfs`)
- 🔧 Fix: Replaced `strcpy` with `strncpy` and added explicit null termination
- ✅ Verification: Run `tests/e2e/e2e.bash`

---
*PR created automatically by Jules for task [13684770713524361043](https://jules.google.com/task/13684770713524361043) started by @emkey1*