### PR TITLE
⚡ Bolt: Eliminate redundant string length calculations in VFS and proc paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2024-05-27 - Hoist strlen and use pointer arithmetic
+**Learning:** O(N) operations like `strlen` cause overhead inside loops (like `fgets` loops reading proc lines). Furthermore, string lengths constructed backwards from known boundaries can be exactly calculated in O(1) via pointer arithmetic instead of relying on `strlen`.
+**Action:** Always hoist `strlen` calls out of loops. When manipulating strings at the end of a buffer, use pointer subtraction `(end - current)` to determine length instead of `strlen`.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -590,7 +590,8 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    size_t p_len = (buf + MAX_PATH - 1) - p;
+    memmove(buf, p, p_len + 1);
     return 0;
 }
 

--- a/kernel/user.c
+++ b/kernel/user.c
@@ -1,3 +1,4 @@
+#include <sys/uio.h>
 #include <string.h>
 #include "kernel/calls.h"
 

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Hoisted `strlen(name)` outside the `do...while` loop in `platform/linux.c:read_proc_line` and replaced `strlen(p)` with pointer arithmetic `(buf + MAX_PATH - 1) - p` in `fs/tmp.c:tmpfs_getpath`.
🎯 Why: To prevent redundant O(N) `strlen` recalculations on every line read from `/proc` and avoid unnecessary string traversals when the exact string length can be computed mathematically.
📊 Impact: Reduces CPU cycles spent computing string lengths, making proc reading and temporary file path generation more efficient.
🔬 Measurement: Verification was completed by running Meson build and executing the full E2E test suite. Performance can be measured via CPU profiling under load reading `/proc/stat` and calling `getcwd` in tmpfs.

---
*PR created automatically by Jules for task [531187113456688748](https://jules.google.com/task/531187113456688748) started by @emkey1*