### PR TITLE
🎨 Palette: Add accessibility traits to action cells in Settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2026-04-16 - Add UIAccessibilityTraitButton to interactive table cells
+**Learning:** Static `UITableViewCell`s acting as actions in iOS Settings screens (like sending feedback, resetting mounts) do not inherently communicate their actionability to screen readers. Relying solely on `didSelectRowAtIndexPath` logic leaves VoiceOver users uninformed.
+**Action:** When adding rows that act as buttons, always implement `tableView:willDisplayCell:forRowAtIndexPath:` to explicitly set `cell.accessibilityTraits |= UIAccessibilityTraitButton;`.

--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -273,6 +273,14 @@ UIViewController *ISHCreateDiagnosticsViewController(void) {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (cell == self.sendFeedback || cell == self.diagnosticsCell || cell == self.initialWindowCell ||
+        cell == self.openGithub || cell == self.openDiscord || cell == self.exportContainerCell ||
+        cell == self.resetMountsCell) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+    }
+}
+
 - (NSString *)_initialWindowPreferenceValue {
     NSString *value = [NSUserDefaults.standardUserDefaults stringForKey:kPreferenceInitialWindowKey];
     if ([value isEqualToString:ISHInitialWindowWorkspaceValue])


### PR DESCRIPTION
**What:** Added `UIAccessibilityTraitButton` to interactive cells in the About/Settings screen.
**Why:** The settings screen contains multiple rows that act as buttons (e.g., Send Feedback, Diagnostics, GitHub, Discord). In VoiceOver, they are read as plain text, leading to confusion since users won't know they are actionable. Adding this trait ensures screen readers announce them properly as buttons.
**Before/After:** No visual changes.
**Accessibility:** Improved VoiceOver experience in the Settings screen by explicitly declaring actionable cells as buttons.

---
*PR created automatically by Jules for task [4712665089956943577](https://jules.google.com/task/4712665089956943577) started by @emkey1*