### PR TITLE
⚡ Bolt: Avoid O(N) strlen in tmpfs_getpath

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2024-05-27 - Optimize backward string construction length calculation
+**Learning:** When constructing strings backwards from the end of a known buffer (e.g., `buf + MAX_PATH - 1`), using `strlen()` to determine the final length causes an unnecessary O(N) string traversal.
+**Action:** Use pointer arithmetic `(buf + MAX_PATH - 1) - p` (or equivalent math based on your starting offset) to calculate the exact string length in O(1) time instead of using `strlen()`.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -590,7 +590,8 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    // Bolt: Calculate length using pointer arithmetic to avoid O(N) strlen
+    memmove(buf, p, (buf + MAX_PATH - 1) - p + 1);
     return 0;
 }
 


### PR DESCRIPTION
💡 What: Replaced `strlen(p)` with pointer arithmetic `(buf + MAX_PATH - 1) - p` in `tmpfs_getpath`.
🎯 Why: When constructing paths backwards from the end of a known buffer, calling `strlen` on the resulting string causes an unnecessary O(N) traversal. Since we know the starting position and the current pointer, we can calculate the length in O(1) time.
📊 Impact: Removes an O(N) operation in a frequently called path resolution function (`tmpfs_getpath`), improving filesystem performance for tmpfs lookups.
🔬 Measurement: Profile the execution time of `tmpfs_getpath` during heavy tmpfs filesystem traversal or stat operations.

---
*PR created automatically by Jules for task [10653338373499576613](https://jules.google.com/task/10653338373499576613) started by @emkey1*