### PR TITLE
🎨 Palette: Add accessibility labels to boot and launch command text fields

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -238,7 +238,9 @@ UIViewController *ISHCreateDiagnosticsViewController(void) {
     self.initialWindowCell.textLabel.text = @"Startup Mode";
     self.initialWindowCell.detailTextLabel.text = [self _initialWindowTitle];
     self.launchCommandField.text = [UserPreferences.shared.launchCommand componentsJoinedByString:@" "];
+    self.launchCommandField.accessibilityLabel = @"Launch command";
     self.bootCommandField.text = [UserPreferences.shared.bootCommand componentsJoinedByString:@" "];
+    self.bootCommandField.accessibilityLabel = @"Boot command";
 
     self.upgradeApkCell.userInteractionEnabled = FsNeedsRepositoryUpdate();
     self.upgradeApkLabel.enabled = FsNeedsRepositoryUpdate();


### PR DESCRIPTION
💡 What: Added `accessibilityLabel`s to the "Launch cmd" and "Boot cmd" text fields in Settings.
🎯 Why: These text fields previously lacked accessibility labels, meaning VoiceOver users would just hear "text field" without knowing what they were for.
📸 Before/After: Visuals remain unchanged. Screen readers now announce "Launch command" and "Boot command".
♿ Accessibility: Added `accessibilityLabel`s to improve screen reader context.

---
*PR created automatically by Jules for task [15293163286731573874](https://jules.google.com/task/15293163286731573874) started by @emkey1*