### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix buffer overflows in filesystem readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## $(date +%Y-%m-%d) - Replace unsafe strcpy calls with strncpy in filesystem readdir operations
+**Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[NAME_MAX + 1]`) in `fs/real.c` and `fs/aok.c` during `readdir` operations.
+**Learning:** Legacy VFS and specific filesystem code often lacks explicit bounds checking, relying on higher-level path validation or assuming external sources (like host filesystems or AOK node basenames) will respect internal `NAME_MAX` limits. This creates defense-in-depth vulnerabilities if `NAME_MAX` bounds are ever exceeded by the source data.
+**Prevention:** Always use `strncpy` and manually ensure null-termination for fixed-size string arrays in the kernel, regardless of upstream path validation or source assumptions.

--- a/fs/aok.c
+++ b/fs/aok.c
@@ -276,7 +276,8 @@ static int aokfs_readdir(struct fd *fd, struct dir_entry *entry) {
     }
 
     entry->inode = aokfs_node_inode(child);
-    strcpy(entry->name, aokfs_node_basename(child));
+    strncpy(entry->name, aokfs_node_basename(child), sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,8 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strncpy(entry->name, dirent->d_name, sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Buffer overflow when using `strcpy` to copy unbounded source paths/names into the `char name[NAME_MAX + 1]` fixed-size array in `fs/real.c` and `fs/aok.c`.
🎯 Impact: If the host filesystem (in `fs/real.c`) or an AOK filesystem node (in `fs/aok.c`) has a file name longer than `NAME_MAX`, `strcpy` will overwrite adjacent memory on the stack/heap, potentially leading to denial of service or code execution.
🔧 Fix: Replaced `strcpy` with `strncpy` bounded to `sizeof(entry->name) - 1` and explicitly set the null terminator.
✅ Verification: Run E2E tests (though currently blocked by sandbox dependency issues). Verified that lengths of copies now never exceed the destination buffer.

---
*PR created automatically by Jules for task [3737947783905898819](https://jules.google.com/task/3737947783905898819) started by @emkey1*