### PR TITLE
⚡ Bolt: Optimize read_proc_line by hoisting strlen()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2024-05-27 - Hoist strlen from proc file parsing loops
+**Learning:** Functions reading files line-by-line, such as `read_proc_line` parsing `/proc` lines with `fgets`, often have invariant string lengths evaluated in the loop condition (`while`). Re-evaluating `strlen()` on loop-invariant variables for each line causes unnecessary O(N) overhead.
+**Action:** Always hoist `strlen()` calls on loop-invariant strings out of file reading loops (e.g., `while`) to avoid recalculating the length on every iteration, caching it in a local variable like `name_len` instead.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,14 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+
+    // Optimization: hoist strlen(name) outside the loop to avoid redundant O(N) recalculations
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Hoisted the `strlen(name)` calculation out of the `do-while` loop in `read_proc_line` within `platform/linux.c`.

🎯 Why: The `read_proc_line` function parses lines from `/proc` files (e.g., `/proc/stat`, `/proc/meminfo`) until it finds a line starting with a specific name. Previously, `strlen(name)` was evaluated in the `while` condition, recalculating the length of the invariant target string for every single line read.

📊 Impact: Reduces redundant O(N) calculations to an O(1) single calculation per function call. For files with many lines (like `/proc/stat`), this eliminates multiple unnecessary string length evaluations per read operation.

🔬 Measurement: Reviewing the updated `read_proc_line` function shows `strlen` is no longer called in the `do-while` loop condition. Verified using the project's standard Meson build and testing processes via terminal (`meson setup build && cd build && ninja` and `./tests/e2e/e2e.bash`).

---
*PR created automatically by Jules for task [1059757175740733499](https://jules.google.com/task/1059757175740733499) started by @emkey1*