### PR TITLE
🎨 Palette: Add accessibility selection state to default filesystem

### DIFF
--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -289,10 +289,16 @@
     }
 
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    BOOL isDefault = [Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot];
+    if (isDefault)
         ident = @"Default Root";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+    if (isDefault) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 **What:** Added `UIAccessibilityTraitSelected` to the currently active (default) filesystem cell in the roots table view, and ensured it's removed for non-default cells.
🎯 **Why:** To allow VoiceOver users to know which filesystem is currently the active/default one when browsing the list. The "Default Root" cell uses a visual checkmark, but the selection state was not conveyed to screen readers.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** VoiceOver will now announce "selected" for the active filesystem.

---
*PR created automatically by Jules for task [16637211537012574749](https://jules.google.com/task/16637211537012574749) started by @emkey1*