### PR TITLE
⚡ Bolt: Hoist strlen() outside loop in read_proc_line

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-03-24 - Hoist loop-invariant strlen calls
+**Learning:** In `platform/linux.c`, the `read_proc_line` function parses `/proc` files line by line using `fgets`. The condition `strncmp(name, buf, strlen(name))` recalculates `strlen(name)` repeatedly for every line in the file until a match is found. This causes redundant O(N) recalculations for a loop-invariant value.
+**Action:** Hoist the `strlen()` call outside the loop, storing the value in a `size_t name_len` variable. Use this cached length in the loop condition to avoid repeated string traversals.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Hoist `strlen(name)` outside the `do-while` loop in `read_proc_line`.
🎯 Why: The `read_proc_line` function parses `/proc` files line by line. The original implementation called `strlen(name)` twice on every iteration of the loop (once for `strncmp` and once for checking the trailing space). Since `name` is a constant string argument, its length does not change. Hoisting `strlen(name)` prevents redundant O(N) string traversals for every line in the `/proc` file.
📊 Impact: Avoids multiple redundant `strlen()` recalculations when reading large proc files like `/proc/stat`, making file parsing marginally faster.
🔬 Measurement: Run the test suite (`./tests/e2e/e2e.bash`) to ensure that `/proc` reading logic remains correct.

---
*PR created automatically by Jules for task [6214817792294560826](https://jules.google.com/task/6214817792294560826) started by @emkey1*