### PR TITLE
🛡️ Sentinel: [High] Fix buffer overflow in host filesystem readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2026-03-27 - Buffer Overflow in Host Filesystem ReadDir
+**Vulnerability:** In `fs/real.c`'s `realfs_readdir`, a host filesystem's directory names (`dirent->d_name`) were copied into the emulator's fixed-size `entry->name` buffer using `strcpy`. If a directory name on the host filesystem exceeds the emulator's `NAME_MAX` (255 characters), it results in a buffer overflow within the emulator process.
+**Learning:** Data crossing the boundary from the host OS into the emulator must be explicitly bounds-checked, as host limits may exceed emulator limits or maliciously crafted host file names could trigger memory corruption.
+**Prevention:** Always use safe copy functions like `strlcpy` when transferring strings from external boundaries (like the host filesystem) into fixed-size structures.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,7 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strlcpy(entry->name, dirent->d_name, sizeof(entry->name));
     return 1;
 }
 


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** The `realfs_readdir` function used `strcpy` to copy directory names from the host filesystem directly into a fixed-size buffer (`entry->name`) in the emulator. If the host filesystem contained a file name exceeding the emulator's `NAME_MAX` limit, a stack buffer overflow would occur.
**Impact:** An attacker could craft excessively long filenames on the host filesystem. When the emulator reads that directory, it triggers a buffer overflow, leading to a Denial of Service (DoS) or potential arbitrary code execution within the emulator process.
**Fix:** Replaced the unsafe `strcpy` with `strlcpy(entry->name, dirent->d_name, sizeof(entry->name))` to enforce strict bounds checking and ensure null-termination based on the destination buffer size.
**Verification:** Code was audited manually, and E2E tests were run (though they fail due to environment constraints).

---
*PR created automatically by Jules for task [18130465933746739975](https://jules.google.com/task/18130465933746739975) started by @emkey1*