### PR TITLE
🎨 Palette: Expose update badge to screen readers and fix root selection accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-29 - Exposing Visual Badges to Screen Readers
+**Learning:** Visual indicators, such as a red badge signaling an available update on the terminal settings button, are invisible to screen readers unless their state is programmatically exposed.
+**Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.

--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -289,10 +289,20 @@
     }
 
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot]) {
         ident = @"Default Root";
+    }
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+    if (self.choosesRootOnSelection) {
+        if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot]) {
+            cell.accessoryType = UITableViewCellAccessoryCheckmark;
+            cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            cell.accessoryType = UITableViewCellAccessoryNone;
+            cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
+    }
     return cell;
 }
 

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -809,6 +809,8 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+    self.infoButton.accessibilityValue = showBadge ? @"Update available" : nil;
+    self.floatingSettingsButton.accessibilityValue = showBadge ? @"Update available" : nil;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
💡 What: Added `accessibilityValue` to the terminal settings button to announce available updates to screen readers, and fixed `UIAccessibilityTraitSelected` state management on root filesystem cells.
🎯 Why: Without explicit `accessibilityValue`, screen reader users miss the visual red badge indicating an update is available. Without explicit clearing of `UIAccessibilityTraitSelected`, reused cells in the root chooser may announce incorrect selection states.
📸 Before/After: Visuals unchanged; screen reader output updated.
♿ Accessibility: Ensures update badges and root selection states are properly announced by VoiceOver.

---
*PR created automatically by Jules for task [10269721405880601844](https://jules.google.com/task/10269721405880601844) started by @emkey1*