### PR TITLE
⚡ Bolt: Hoist strlen() in read_proc_line to prevent redundant recalculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-03-25 - Hoist strlen outside of proc reading loops
+**Learning:** In `platform/linux.c`, calling `strlen` on a loop-invariant string (like `name` in `read_proc_line`) inside a `while` loop that reads lines via `fgets` causes redundant O(N) string traversals on every iteration.
+**Action:** Always cache the length of loop-invariant target strings outside the loop (e.g., `size_t name_len = strlen(name);`) to avoid redundant O(N) recalculations and improve performance.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
**What:** Hoisted the `strlen(name)` call outside of the `do...while` loop in `read_proc_line` within `platform/linux.c`.
**Why:** The original implementation repeatedly called `strlen()` inside a file-reading loop, incurring O(N) calculations for the loop-invariant string `name` on every iteration, leading to unnecessary overhead.
**Impact:** Avoids redundant O(N) recalculations of string length during `/proc` file parsing, improving the efficiency of operations that read proc statistics.
**Measurement:** Verified code correctness by executing `./tests/e2e/e2e.bash`.

---
*PR created automatically by Jules for task [6774196691566097120](https://jules.google.com/task/6774196691566097120) started by @emkey1*