### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in realfs_readdir

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,8 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+
+## 2024-05-23 - Buffer Overflow in Host Filesystem Interface
+**Vulnerability:** In `fs/real.c`, `strcpy(entry->name, dirent->d_name)` copied directory entry names from the host OS into the emulator's `dir_entry` struct. The host's `d_name` length limit could exceed the emulator's internal `NAME_MAX`, causing a stack or heap buffer overflow depending on where `dir_entry` was allocated.
+**Learning:** Data crossing the boundary from the host OS into the emulator must always be explicitly bounds-checked, as host OS limits cannot be assumed to match the emulator's internal limits.
+**Prevention:** Always use `strlcpy` and `sizeof()` of the destination buffer when copying strings from host OS structures (like `struct dirent`) to emulator structures.

--- a/fs/real.c
+++ b/fs/real.c
@@ -178,7 +178,7 @@ int realfs_readdir(struct fd *fd, struct dir_entry *entry) {
             return 0;
     }
     entry->inode = dirent->d_ino;
-    strcpy(entry->name, dirent->d_name);
+    strlcpy(entry->name, dirent->d_name, sizeof(entry->name));
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unbounded `strcpy` in `fs/real.c` when copying host filesystem directory names into the emulator's internal `dir_entry` struct.
🎯 Impact: If a host directory name exceeds `NAME_MAX`, it will cause a buffer overflow in the emulator, potentially leading to arbitrary code execution or a denial of service.
🔧 Fix: Replaced `strcpy` with `strlcpy`, ensuring the copy is bounded by `sizeof(entry->name)`.
✅ Verification: Verified using E2E tests (`./tests/e2e/e2e.bash`).

---
*PR created automatically by Jules for task [9806936907514814](https://jules.google.com/task/9806936907514814) started by @emkey1*