### PR TITLE
🎨 Palette: Improve accessibility of root filesystem selection

### DIFF
--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -289,10 +289,18 @@
     }
 
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    BOOL isDefault = [Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot];
+    if (isDefault)
         ident = @"Default Root";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+    if (isDefault) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     return cell;
 }
 


### PR DESCRIPTION
💡 **What**: Explicitly manage `accessoryType` and `UIAccessibilityTraitSelected` for reusable table view cells in `RootsTableViewController`.
🎯 **Why**: When `UITableViewCell`s are reused, relying solely on prototype cell reuse identifiers or implicitly leaving visual state uncleared can cause bugs where unselected cells appear selected. Additionally, VoiceOver cannot announce a cell as selected if only a visual checkmark is present.
📸 **Before/After**: No visual change to correctly functioning cells, but avoids visual glitches upon scrolling and fixes missing screen reader state.
♿ **Accessibility**: Properly sets `UIAccessibilityTraitSelected` for the default root cell, allowing VoiceOver to announce its selected state. Clears the trait on unselected roots.

---
*PR created automatically by Jules for task [10503405789036795751](https://jules.google.com/task/10503405789036795751) started by @emkey1*