### PR TITLE
🎨 Palette: Add accessibility labels to text fields

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -171,6 +171,9 @@ UIViewController *ISHCreateDiagnosticsViewController(void) {
                           [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
                           [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]];
 
+    self.launchCommandField.accessibilityLabel = @"Launch Command";
+    self.bootCommandField.accessibilityLabel = @"Boot Command";
+
     [UserPreferences.shared observe:@[@"capsLockMapping", @"fontSize", @"launchCommand", @"bootCommand", @"shouldLockSleepNanoseconds"]
                             options:0 owner:self usingBlock:^(typeof(self) self) {
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
💡 **What**: Added explicit `accessibilityLabel` attributes to the `launchCommandField` and `bootCommandField` text fields in `app/AboutViewController.m`.
🎯 **Why**: These text fields lacked accessibility labels, which made it difficult for VoiceOver users to understand their purpose when navigating the app's settings.
📸 **Before/After**: 
- **Before**: Text fields were read without context by VoiceOver.
- **After**: VoiceOver reads "Launch Command" and "Boot Command" respectively for these text fields.
♿ **Accessibility**: Improves keyboard and screen reader navigation by providing clear, descriptive labels for interactive text fields.

---
*PR created automatically by Jules for task [4167986173071963681](https://jules.google.com/task/4167986173071963681) started by @emkey1*