### PR TITLE
⚡ Bolt: Optimize string operations in read_proc_line

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-03-25 - Hoist strlen from read_proc_line loop
+**Learning:** In `platform/linux.c`, functions reading from `/proc` files via `fgets` inside a `while` loop evaluated `strlen(name)` twice on each iteration. This causes redundant O(N) recalculations for loop-invariant variables.
+**Action:** Hoist loop-invariant `strlen(name)` calls outside of `while` loops reading from `/proc` files to prevent performance degradation during string parsing.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
**What:** Hoisted the loop-invariant `strlen(name)` out of the `read_proc_line` `do-while` loop in `platform/linux.c`.
**Why:** `strlen()` was being called twice per line parsed, which is inefficient.
**Impact:** Reduces unnecessary O(N) string length calculations during `/proc` file parsing.
**Measurement:** Confirmed using syntax checks and manual inspection of the logic.

---
*PR created automatically by Jules for task [10595499349613094580](https://jules.google.com/task/10595499349613094580) started by @emkey1*