### PR TITLE
⚡ Bolt: Optimize read_proc_line performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-03-25 - Avoid redundant strlen in read_proc_line
+**Learning:** In `platform/linux.c`, `read_proc_line` uses a `while` loop that continuously recalculates `strlen(name)` on every single line read from a `/proc` file.
+**Action:** Cache the result of `strlen(name)` outside of the loop to prevent O(N) recalculations, saving unnecessary operations during file parsing.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
### What
Cached the length of `name` in `read_proc_line` instead of recalculating it on every loop iteration.

### Why
The loop iterates over lines in `/proc` files using `fgets`. Calling `strlen(name)` repeatedly on the unchanged string incurs unnecessary recalculations.

### Impact
Reduces O(N) `strlen` recalculations (where N is the number of lines in the file) to a single O(1) evaluation, slightly speeding up `/proc` parsing.

### Measurement
Measurements confirm reduction in loop overhead during `/proc` file reading. Validated via the E2E test suite.

---
*PR created automatically by Jules for task [6489969003586381578](https://jules.google.com/task/6489969003586381578) started by @emkey1*