### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix kernel memory corruption in flock_from_file_lock

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2024-04-26 - Fix reversed strncpy in flock_from_file_lock
+**Vulnerability:** The function `flock_from_file_lock` reversed the source and destination arguments of `strncpy`, copying uninitialized user memory (`flock->comm`) into the kernel's lock structure (`lock->comm`).
+**Learning:** Reversing `strncpy` directions when copying data from kernel structures to user structures can overwrite critical kernel state with arbitrary user data, leading to memory corruption.
+**Prevention:** Always ensure string copy directions flow strictly from kernel state to user state when populating user-facing structures. Use `sizeof(destination)` instead of hardcoded magic numbers like `16` to prevent buffer overflows and ensure robustness.

--- a/fs/lock.c
+++ b/fs/lock.c
@@ -47,7 +47,7 @@ static struct file_lock *file_lock_copy(struct file_lock *request) {
     lock->type = request->type;
     lock->owner = request->owner;
     lock->pid = request->pid;
-    strncpy(lock->comm, request->comm, 16);
+    strncpy(lock->comm, request->comm, sizeof(lock->comm));
     list_init(&lock->locks);
     return lock;
 }
@@ -184,7 +184,7 @@ static int file_lock_from_flock(struct fd *fd, struct flock_ *flock, struct file
     lock->type = flock->type;
     lock->owner = current->files;
     lock->pid = current->pid;
-    strncpy(lock->comm, current->comm, 16);
+    strncpy(lock->comm, current->comm, sizeof(lock->comm));
     return 0;
 }
 
@@ -197,7 +197,7 @@ static int flock_from_file_lock(struct file_lock *lock, struct flock_ *flock) {
     else
         flock->len = 0;
     flock->pid = lock->pid;
-    strncpy(lock->comm, flock->comm, 16);
+    strncpy(flock->comm, lock->comm, sizeof(flock->comm));
     return 0;
 }
 


### PR DESCRIPTION
Severity: CRITICAL
Vulnerability: `flock_from_file_lock` reversed the source and destination arguments of `strncpy`, copying uninitialized user memory into the kernel's lock structure. This allows memory corruption in the kernel. `strncpy` hardcoded lengths were also fixed.
Impact: An attacker could write uninitialized memory or arbitrary data into the kernel lock state, potentially causing a crash or arbitrary code execution.
Fix: Corrected `strncpy` arguments to correctly copy from `lock->comm` to `flock->comm` using `sizeof(flock->comm)`. Fixed hardcoded `16` buffer lengths in other `strncpy` uses for consistency.
Verification: Ran E2E tests using `./tests/e2e/e2e.bash`.

---
*PR created automatically by Jules for task [8716833016311993577](https://jules.google.com/task/8716833016311993577) started by @emkey1*