### PR TITLE
⚡ Bolt: Optimize strlen in read_proc_line

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2024-05-27 - Hoist strlen outside of loop in read_proc_line
+**Learning:** In `platform/linux.c`, `read_proc_line` calculates `strlen(name)` in the `while` loop condition, which causes redundant O(N) recalculations for every line read from `/proc` files.
+**Action:** When repeatedly checking the same string against a buffer in a loop (like reading lines from `/proc`), hoist `strlen()` calls on the invariant target string outside the loop to prevent unnecessary O(N) recalculations.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 **What**: Hoisted `strlen(name)` outside of the `do-while` loop in `read_proc_line` (`platform/linux.c`).
🎯 **Why**: The loop condition was calling `strlen(name)` multiple times while parsing lines from `/proc` files. `name` is invariant, so this was unnecessarily causing O(N) string length recalculations for every line parsed.
📊 **Impact**: Reduces CPU cycles wasted calculating `strlen` during proc file parsing. Time complexity per line parsing check goes from O(N) to O(1).
🔬 **Measurement**: Verify by running tests that rely on Linux procfs info (e.g., e2e tests), or using `strace` or profiling if available on `/proc` reads.

---
*PR created automatically by Jules for task [6133049547762918647](https://jules.google.com/task/6133049547762918647) started by @emkey1*