### PR TITLE
🎨 Palette: Add accessibility button traits to action cells in About tab

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-13 - Add Button Trait to Action Cells in AboutViewController
+**Learning:** In iOS, static `UITableViewCell`s used as actions do not inherently possess `UIAccessibilityTraitButton`. This causes screen readers to announce them merely as text, rather than actionable buttons.
+**Action:** Always explicitly add `UIAccessibilityTraitButton` to static `UITableViewCell`s that trigger actions (e.g., links, dialogs, resets) in `tableView:willDisplayCell:forRowAtIndexPath:` to ensure robust screen reader context.

--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -273,6 +273,12 @@ UIViewController *ISHCreateDiagnosticsViewController(void) {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (cell == self.sendFeedback || cell == self.diagnosticsCell || cell == self.initialWindowCell || cell == self.openGithub || cell == self.openDiscord || cell == self.exportContainerCell || cell == self.resetMountsCell) {
+        cell.accessibilityTraits |= UIAccessibilityTraitButton;
+    }
+}
+
 - (NSString *)_initialWindowPreferenceValue {
     NSString *value = [NSUserDefaults.standardUserDefaults stringForKey:kPreferenceInitialWindowKey];
     if ([value isEqualToString:ISHInitialWindowWorkspaceValue])


### PR DESCRIPTION
**What:** Added `UIAccessibilityTraitButton` to static `UITableViewCell` elements in the About View that behave as actions (e.g., Send Feedback, Diagnostics, GitHub, Discord, Export, Reset).
**Why:** Static cells do not inherently possess button traits. Without this trait, VoiceOver and other screen readers announce these actionable cells merely as text, which provides insufficient context to users relying on assistive technologies that they can be activated.
**Before/After:** N/A (Non-visual accessibility change)
**Accessibility:** Improved VoiceOver experience by ensuring all actionable table cells are properly announced as buttons, allowing screen reader users to understand they can interact with these elements.

---
*PR created automatically by Jules for task [390950753771934077](https://jules.google.com/task/390950753771934077) started by @emkey1*