### PR TITLE
⚡ Bolt: Optimize read_proc_line string parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2026-03-25 - Avoid loop-invariant strlen in procfile parsing
+**Learning:** In string parsing functions reading from procfiles (e.g., `read_proc_line` via `fgets`), calling `strlen()` on a loop-invariant search target inside the loop condition causes redundant O(N) overhead for every line read.
+**Action:** Hoist loop-invariant `strlen()` calculations outside the parsing loop and cache the result to prevent unnecessary recalculations.

--- a/platform/linux.c
+++ b/platform/linux.c
@@ -10,11 +10,12 @@
 static void read_proc_line(const char *file, const char *name, char *buf) {
     FILE *f = fopen(file, "r");
     if (f == NULL) ERRNO_DIE(file);
+    size_t name_len = strlen(name);
     do {
         fgets(buf, 1234, f);
         if (feof(f))
             die("could not find proc line %s", name);
-    } while (!(strncmp(name, buf, strlen(name)) == 0 && buf[strlen(name)] == ' '));
+    } while (!(strncmp(name, buf, name_len) == 0 && buf[name_len] == ' '));
     fclose(f);
 }
 


### PR DESCRIPTION
💡 What: Hoist loop-invariant `strlen(name)` outside the `do...while` loop in `platform/linux.c`'s `read_proc_line`.
🎯 Why: Avoids recalculating `strlen()` twice per iteration when reading multiple lines from `/proc` files like `/proc/stat`.
📊 Impact: Eliminates O(N) redundant string traversals on every line read from `/proc` targets.
🔬 Measurement: Verified via Meson/Ninja compilation and E2E test execution.

---
*PR created automatically by Jules for task [13228370189619511011](https://jules.google.com/task/13228370189619511011) started by @emkey1*