### PR TITLE
⚡ Bolt: Optimize getdents by avoiding redundant strlen calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+## 2024-05-27 - Optimize getdents by avoiding redundant strlen calculations
+**Learning:** In `fs/dir.c`, the `sys_getdents_common` function iterates over directory entries and calls a `fill_dirent` function pointer. This caused `strlen` to be called twice per entry: once in `sys_getdents_common` to calculate the allocation size and again inside the `fill_dirent` implementations (`fill_dirent_32`, `fill_dirent_64`). This incurs redundant O(N) operations in a hot path.
+**Action:** When a string length is already computed or known by a caller (like for bounds checking or allocation sizing), pass that length explicitly to the callee as a parameter (e.g. adding `namelen` to `fill_dirent`) rather than recalculating it with `strlen()` inside the inner functions.

--- a/fs/dir.c
+++ b/fs/dir.c
@@ -35,22 +35,20 @@ struct linux_dirent64_ {
     char name[];
 } __attribute__((packed));
 
-size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent_, name) + namelen + 1; // name, null terminator, type
     memcpy(dirent->name, name, namelen);
     *((char *) dirent + dirent->reclen - 1) = type;
     return dirent->reclen;
 }
 
-size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent64_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent64_, name) + namelen; // name, null terminator
     dirent->type = type;
     memcpy(dirent->name, name, namelen);
@@ -58,7 +56,7 @@ size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char 
 }
 
 int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
-        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int)) {
+        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, size_t, int)) {
     STRACE("getdents(%d, %#x, %#x)", f, dirents, count);
     struct fd *fd = f_get(f);
     if (fd == NULL)
@@ -85,14 +83,16 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         if (err == 0)
             break;
 
-        size_t max_reclen = sizeof(struct linux_dirent64_) + strlen(entry.name) + 4;
+        size_t name_len_without_null = strlen(entry.name);
+        size_t namelen = name_len_without_null + 1; // Include null terminator
+        size_t max_reclen = sizeof(struct linux_dirent64_) + name_len_without_null + 4;
         char dirent_data[max_reclen];
         dirent_data[0] = 0;
         ino_t inode = entry.inode;
         off_t_ offset = fd_telldir(fd);
         const char *name = entry.name;
         int type = 0;
-        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type);
+        size_t reclen = fill_dirent(dirent_data, inode, offset, name, namelen, type);
         if (printed < 20) {
             STRACE(" {inode=%d, offset=%d, name=%s, type=%d, reclen=%d}",
                     inode, offset, name, type, reclen);


### PR DESCRIPTION
💡 What: Updated `sys_getdents_common` and its `fill_dirent` callbacks (`fill_dirent_32`, `fill_dirent_64`) in `fs/dir.c` to compute the directory entry name length only once and pass it down as a parameter, instead of calling `strlen` repeatedly.
🎯 Why: In the hot loop reading directory entries, `strlen` was evaluated once for `max_reclen` and then again inside `fill_dirent_32` or `fill_dirent_64`. Avoiding redundant string length calculation improves performance of `getdents` system calls, which are very common.
📊 Impact: Halves the number of `strlen` operations per directory entry processed during `getdents` and `getdents64` syscalls.
🔬 Measurement: Performance improvements can be verified by running directory listing or traversal benchmarks (like `ls -R` or `find`) and measuring CPU time spent in `sys_getdents_common`.

---
*PR created automatically by Jules for task [1671403404367003239](https://jules.google.com/task/1671403404367003239) started by @emkey1*