### PR TITLE
🎨 Palette: Add accessibility value for update badges on settings buttons

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -809,6 +809,10 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+
+    NSString *badgeValue = showBadge ? @"Update available" : nil;
+    self.infoButton.accessibilityValue = badgeValue;
+    self.floatingSettingsButton.accessibilityValue = badgeValue;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
- **What:** Exposes the update available badge on the settings buttons to screen readers by setting their `accessibilityValue`.
- **Why:** VoiceOver users cannot see the visual red dot badge that indicates an update is available; this ensures parity for screen reader users.
- **Before/After:** No visual changes.
- **Accessibility:** Adds `accessibilityValue` of "Update available" when the badge is shown, adhering to VoiceOver best practices.

---
*PR created automatically by Jules for task [14065375373096187738](https://jules.google.com/task/14065375373096187738) started by @emkey1*