### PR TITLE
🎨 Palette: Expose settings visual badges to screen readers

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -809,6 +809,9 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+    NSString *badgeValue = showBadge ? @"Update available" : nil;
+    self.infoButton.accessibilityValue = badgeValue;
+    self.floatingSettingsButton.accessibilityValue = badgeValue;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {


### PR DESCRIPTION
💡 **What**: Added `accessibilityValue` ("Update available") to the `infoButton` and `floatingSettingsButton` whenever their corresponding visual update badges (`settingsBadge`, `floatingSettingsBadge`) are displayed, and cleared it (`nil`) when hidden.
🎯 **Why**: Previously, the visual update badge on the settings icon was invisible to screen readers, leaving VoiceOver users unaware that an update was available. Exposing this through `accessibilityValue` keeps the main `accessibilityLabel` clean while still announcing the critical state change.
📸 **Before/After**: 
  - Before: Settings button just announced as "Settings. Opens the application settings." when an update is available. 
  - After: Settings button announces as "Settings. Update available. Opens the application settings."
♿ **Accessibility**: Directly fixes a critical missing accessibility state for visual badges, aligning with best practices for exposing update indicators.

---
*PR created automatically by Jules for task [1883571951532030827](https://jules.google.com/task/1883571951532030827) started by @emkey1*