### PR TITLE
🛡️ Sentinel: [High] Fix authorization bypass in sethostname syscall

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2026-03-24 - Optimize dynamic string construction
 **Learning:** In `fs/proc/ish.c`, the `parse_if_flags` function used `strcat` to append strings dynamically, which causes O(N) traversal to find the end of the string for every append.
 **Action:** Replace `strcat` in dynamic string construction with `memcpy` using pre-calculated string lengths. By keeping track of the current string length `len`, appending becomes an O(1) operation.
+
+## 2026-03-25 - Hoist string length calculations in VFS inner functions
+**Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
+**Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2024-05-02 - Privilege Escalation via Direct UID Checks
+**Vulnerability:** In `kernel/uname.c`, the `sys_sethostname` syscall checked for privilege using `current->uid != 0` instead of evaluating the effective user ID (`euid`). This incorrect direct `uid` check allowed processes that have dropped effective privileges (but retained a real `uid` of 0) to bypass security checks and improperly alter the system hostname.
+**Learning:** Legacy direct `uid` checks do not accurately reflect the current privilege level of a task and can lead to authorization bypasses when `uid` and `euid` diverge.
+**Prevention:** Always use the `superuser()` macro for privilege checks in the iSH kernel to properly validate the effective user ID (`current->euid == 0`).

--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -809,6 +809,9 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     BOOL showBadge = FsNeedsRepositoryUpdate();
     self.settingsBadge.hidden = !showBadge;
     self.floatingSettingsBadge.hidden = !showBadge;
+    NSString *badgeValue = showBadge ? @"Update available" : nil;
+    self.infoButton.accessibilityValue = badgeValue;
+    self.floatingSettingsButton.accessibilityValue = badgeValue;
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {

--- a/fs/dir.c
+++ b/fs/dir.c
@@ -35,22 +35,20 @@ struct linux_dirent64_ {
     char name[];
 } __attribute__((packed));
 
-size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_32(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent_, name) + namelen + 1; // name, null terminator, type
     memcpy(dirent->name, name, namelen);
     *((char *) dirent + dirent->reclen - 1) = type;
     return dirent->reclen;
 }
 
-size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, int type) {
+size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char *name, size_t namelen, int type) {
     struct linux_dirent64_ *dirent = dirent_data;
     dirent->inode = inode;
     dirent->offset = offset;
-    const size_t namelen = strlen(name) + 1; // Include null terminator
     dirent->reclen = offsetof(struct linux_dirent64_, name) + namelen; // name, null terminator
     dirent->type = type;
     memcpy(dirent->name, name, namelen);
@@ -58,7 +56,7 @@ size_t fill_dirent_64(void *dirent_data, ino_t inode, off_t_ offset, const char 
 }
 
 int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
-        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, int)) {
+        size_t (*fill_dirent)(void *, ino_t, off_t_, const char *, size_t, int)) {
     STRACE("getdents(%d, %#x, %#x)", f, dirents, count);
     struct fd *fd = f_get(f);
     if (fd == NULL)
@@ -85,14 +83,15 @@ int_t sys_getdents_common(fd_t f, addr_t dirents, dword_t count,
         if (err == 0)
             break;
 
-        size_t max_reclen = sizeof(struct linux_dirent64_) + strlen(entry.name) + 4;
+        size_t name_len = strlen(entry.name);
+        size_t max_reclen = sizeof(struct linux_dirent64_) + name_len + 4;
         char dirent_data[max_reclen];
         dirent_data[0] = 0;
         ino_t inode = entry.inode;
         off_t_ offset = fd_telldir(fd);
         const char *name = entry.name;
         int type = 0;
-        size_t reclen = fill_dirent(dirent_data, inode, offset, name, type);
+        size_t reclen = fill_dirent(dirent_data, inode, offset, name, name_len + 1, type);
         if (printed < 20) {
             STRACE(" {inode=%d, offset=%d, name=%s, type=%d, reclen=%d}",
                     inode, offset, name, type, reclen);

--- a/kernel/uname.c
+++ b/kernel/uname.c
@@ -71,7 +71,7 @@ dword_t sys_uname(addr_t uts_addr) {
 dword_t sys_sethostname(addr_t hostname_addr, dword_t hostname_len) {
     struct uname uts;
 
-    if (current->uid != 0) {
+    if (!superuser()) {
         return _EPERM;
     }
 


### PR DESCRIPTION
**Severity:** High

**Vulnerability:** The `sys_sethostname` syscall in `kernel/uname.c` incorrectly checked for privileges using `current->uid != 0` instead of checking the effective user ID (`current->euid`). 

**Impact:** A process that temporarily drops privileges (so `euid != 0`) but keeps a real user ID of 0 (`uid == 0`) could still successfully call `sys_sethostname` and modify the system hostname. This represents an authorization bypass.

**Fix:** Refactored the code to use the `superuser()` macro (defined in `kernel/task.h`), which properly checks if the effective user ID is zero (`current->euid == 0`), closing the privilege escalation vulnerability.

**Verification:** Ran the E2E test suite (`./tests/e2e/e2e.bash`).

---
*PR created automatically by Jules for task [4227818733254378821](https://jules.google.com/task/4227818733254378821) started by @emkey1*