### PR TITLE
🎨 Palette: Add selection traits to dock buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Dynamically Updating Accessibility Traits for Dock Buttons
+**Learning:** Dock buttons in `WorkspaceViewController.m` act as workspace window tabs, but they previously didn't apply selection traits when a window was focused (`frontmost`), leaving screen reader users without explicit indication of the currently active window.
+**Action:** When configuring dock tile buttons, dynamically add `UIAccessibilityTraitSelected` using `|=` if the window is `frontmost`, and remove it using `&= ~` if it isn't.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -2185,6 +2185,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     button.backgroundColor = fillColor;
     button.layer.borderColor = borderColor.CGColor;
     button.accessibilityValue = state;
+    if (frontmost) {
+        button.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (UIView *)workspaceCardWithContentStack:(UIStackView **)contentStackOut {


### PR DESCRIPTION
**💡 What:** Added `UIAccessibilityTraitSelected` to workspace dock buttons when they are the frontmost/active window.
**🎯 Why:** To ensure screen reader users are explicitly aware of which window is currently active in the workspace dock, aligning with the standard iOS accessibility pattern for selected states.
**📸 Before/After:** N/A (Non-visual accessibility change)
**♿ Accessibility:** VoiceOver will now announce the frontmost dock button as "selected", improving spatial awareness for users relying on assistive technologies.

---
*PR created automatically by Jules for task [8073034080035115745](https://jules.google.com/task/8073034080035115745) started by @emkey1*