### PR TITLE
🎨 Palette: Add selected accessibility trait to dock tile buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-06-15 - Dock Tile Button Selection Accessibility
+**Learning:** Dock tile buttons function as tabs for workspace windows. Without `UIAccessibilityTraitSelected`, screen reader users cannot easily determine the active (frontmost) window from the dock.
+**Action:** Explicitly set or clear `UIAccessibilityTraitSelected` using bitwise operators based on the `frontmost` state for dock tile buttons.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -2185,6 +2185,12 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     button.backgroundColor = fillColor;
     button.layer.borderColor = borderColor.CGColor;
     button.accessibilityValue = state;
+
+    if (frontmost) {
+        button.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (UIView *)workspaceCardWithContentStack:(UIStackView **)contentStackOut {


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` to dock tile buttons when they are the frontmost window.
🎯 Why: Dock tile buttons act as tabs, but their selection state wasn't exposed to VoiceOver, making it difficult for screen reader users to know which window is currently active.
📸 Before/After: Visuals remain unchanged, but VoiceOver now announces the frontmost button as "selected".
♿ Accessibility: Improves navigation for VoiceOver users by correctly indicating the selected tab/window in the dock.

---
*PR created automatically by Jules for task [12865594755092548169](https://jules.google.com/task/12865594755092548169) started by @emkey1*