### PR TITLE
🎨 Palette: Add accessibility trait for selected dock tiles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Tab Selection Accessibility
+**Learning:** When custom buttons function as tabs (like dock tiles representing active workspace windows), visual selection cues (like background color and being "frontmost") are not conveyed to VoiceOver automatically.
+**Action:** Explicitly set the `UIAccessibilityTraitSelected` trait dynamically based on the active or selected property (e.g. `frontmost`) so screen reader users know which tab is currently selected.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -2185,6 +2185,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     button.backgroundColor = fillColor;
     button.layer.borderColor = borderColor.CGColor;
     button.accessibilityValue = state;
+    if (frontmost) {
+        button.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (UIView *)workspaceCardWithContentStack:(UIStackView **)contentStackOut {


### PR DESCRIPTION
**What:** Added `UIAccessibilityTraitSelected` to dock tile buttons in the workspace when they represent the frontmost window.
**Why:** Dock tiles act as tabs representing workspace windows. VoiceOver users need to know which one is currently selected/active.
**Before/After:** No visual changes. VoiceOver now correctly announces the selected state of the frontmost dock tile.
**Accessibility:** Enhances VoiceOver tab state announcements for workspace windows.

---
*PR created automatically by Jules for task [8418840536389468050](https://jules.google.com/task/8418840536389468050) started by @emkey1*