### PR TITLE
🎨 Palette: Explicitly mark active filesystem for VoiceOver

### DIFF
--- a/app/RootsTableViewController.m
+++ b/app/RootsTableViewController.m
@@ -329,10 +329,18 @@
     }
 
     NSString *ident = @"Root";
-    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot])
+    if ([Roots.instance.roots[indexPath.row] isEqual:Roots.instance.defaultRoot]) {
         ident = @"Default Root";
+    }
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:ident forIndexPath:indexPath];
     cell.textLabel.text = Roots.instance.roots[indexPath.row];
+
+    if ([ident isEqualToString:@"Default Root"]) {
+        cell.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        cell.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
+
     return cell;
 }
 


### PR DESCRIPTION
### What
Explicitly sets `UIAccessibilityTraitSelected` for the default (active) filesystem root cell in `RootsTableViewController` and clears it for unselected cells.

### Why
Currently, the active filesystem is visually distinguished by using the "Default Root" cell reuse identifier, but its selected state isn't explicitly communicated to VoiceOver. VoiceOver users would not be able to easily identify the currently active filesystem among the list of installed filesystems.

### Before/After
No visual changes.

### Accessibility
Screen readers will now announce "Selected" when focusing on the currently active filesystem in the Installed Filesystems list.

---
*PR created automatically by Jules for task [7614588667406145493](https://jules.google.com/task/7614588667406145493) started by @emkey1*