### PR TITLE
🎨 Palette: [UX improvement] Indicate selected workspace windows with UIAccessibilityTraitSelected

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -2185,6 +2185,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     button.backgroundColor = fillColor;
     button.layer.borderColor = borderColor.CGColor;
     button.accessibilityValue = state;
+    if (frontmost) {
+        button.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
 }
 
 - (UIView *)workspaceCardWithContentStack:(UIStackView **)contentStackOut {


### PR DESCRIPTION
💡 **What**: Added `UIAccessibilityTraitSelected` to dock tile buttons in `WorkspaceViewController` when their respective window is `frontmost`, and cleared it when it is not.
🎯 **Why**: To accurately indicate the selected state of the workspace windows functioning as tabs for VoiceOver users.
📸 **Before/After**: No visual changes, VoiceOver accessibility enhancement.
♿ **Accessibility**: Exposes proper selected states to screen readers when tabs are activated.

---
*PR created automatically by Jules for task [227153990201726318](https://jules.google.com/task/227153990201726318) started by @emkey1*