### PR TITLE
🎨 Palette: Improve accessibility for active workspace scene buttons

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6443,6 +6443,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)


### PR DESCRIPTION
💡 What: Applies the `UIAccessibilityTraitSelected` trait to the currently active workspace scene button, and clears it from inactive ones.
🎯 Why: Visual indicators (like border color and background color) are used to show which scene is active, but this state is not announced to VoiceOver users. By correctly applying the selected trait, screen readers will announce the active scene accurately.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Added `UIAccessibilityTraitSelected` for the current workspace scene button in `workspaceApplyTheme` to explicitly convey selection state.

---
*PR created automatically by Jules for task [4845919787261802398](https://jules.google.com/task/4845919787261802398) started by @emkey1*