### PR TITLE
🎨 Palette: Add accessibility traits to active workspace buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Workspace Scene Button Selection Accessibility
+**Learning:** Workspace scene buttons and browser tab buttons in the app's workspace dynamically change their visual state (background and border color) based on selection but failed to update their `accessibilityTraits`. This leaves VoiceOver users unaware of the active scene or tab.
+**Action:** Always dynamically apply `UIAccessibilityTraitSelected` (`|=`) to active scene/tab buttons and clear it (`&= ~`) for inactive ones when updating their visual styles.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6443,6 +6443,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)
@@ -6990,6 +6995,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
         button.layer.borderColor = (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         [button setTitleColor:(selected ? theme[@"accent"] : theme[@"primary"]) forState:UIControlStateNormal];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     _addressContainerView.backgroundColor = [theme[@"backgroundTop"] colorWithAlphaComponent:0.18];
     _addressContainerView.layer.borderColor = theme[@"stroke"].CGColor;


### PR DESCRIPTION
### 💡 What
Added dynamic application of `UIAccessibilityTraitSelected` to workspace scene buttons and browser tab buttons in `workspaceApplyTheme` based on their active states.

### 🎯 Why
While the buttons visually changed color and borders when selected, VoiceOver users were not notified of their selected state. Adding `UIAccessibilityTraitSelected` natively indicates to screen readers which workspace scene or tab is active.

### 📸 Before/After
No visual changes.

### ♿ Accessibility
- VoiceOver now correctly announces the selected state of active workspace scenes and active browser tabs, rather than treating them as standard unselected buttons.

---
*PR created automatically by Jules for task [8337528508875730470](https://jules.google.com/task/8337528508875730470) started by @emkey1*