### PR TITLE
🎨 Palette: Add accessibility traits to workspace and browser buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-14 - Accessibility Traits in Theme Methods
+**Learning:** In app/WorkspaceViewController.m, workspace scene buttons and browser tab buttons dynamically change their visual state based on selection inside `workspaceApplyTheme`. However, this visual selection state is not conveyed to VoiceOver users.
+**Action:** When updating the visual styles for active/inactive buttons, always dynamically apply `UIAccessibilityTraitSelected` (`|=`) to active buttons and clear it (`&= ~`) for inactive ones to ensure VoiceOver users are aware of the active state.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6443,6 +6443,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)
@@ -6990,6 +6995,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
         button.layer.borderColor = (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         [button setTitleColor:(selected ? theme[@"accent"] : theme[@"primary"]) forState:UIControlStateNormal];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     _addressContainerView.backgroundColor = [theme[@"backgroundTop"] colorWithAlphaComponent:0.18];
     _addressContainerView.layer.borderColor = theme[@"stroke"].CGColor;


### PR DESCRIPTION
**What:** Added `UIAccessibilityTraitSelected` to workspace scene buttons and browser tab buttons based on their current active state.
**Why:** To ensure VoiceOver users are aware of the active state of these buttons when their visual styles are updated.
**Before/After:** No visual changes.
**Accessibility:** Improved screen reader visibility by correctly setting the selected trait for toggleable buttons.

---
*PR created automatically by Jules for task [11215445266706313993](https://jules.google.com/task/11215445266706313993) started by @emkey1*