### PR TITLE
🎨 Palette: Improve accessibility of selected workspace buttons

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6443,6 +6443,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)
@@ -6990,6 +6995,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
         button.layer.borderColor = (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         [button setTitleColor:(selected ? theme[@"accent"] : theme[@"primary"]) forState:UIControlStateNormal];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     _addressContainerView.backgroundColor = [theme[@"backgroundTop"] colorWithAlphaComponent:0.18];
     _addressContainerView.layer.borderColor = theme[@"stroke"].CGColor;


### PR DESCRIPTION
- **💡 What:** Added dynamic setting of `UIAccessibilityTraitSelected` on workspace scene buttons and browser tab buttons in `app/WorkspaceViewController.m`.
- **🎯 Why:** Previously, the visual selection states of these buttons (such as distinct background and border colors) were not exposed to screen reader users. By properly updating the accessibility traits, VoiceOver will now announce when a scene or tab is active.
- **♿ Accessibility:** This adheres to iOS accessibility best practices by ensuring visual state changes corresponding to "selection" (or activation) are conveyed semantically, which directly addresses the learning from `.jules/palette.md` to use `UIAccessibilityTraitSelected` dynamically based on state rather than solely relying on visual styles or custom string values.

---
*PR created automatically by Jules for task [2367332761585313282](https://jules.google.com/task/2367332761585313282) started by @emkey1*