### PR TITLE
🛡️ Sentinel: [Low] Fix buffer overflow risk in process tools

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-03-27 - Buffer Overflow Risk in Process Tools
+**Vulnerability:** Use of `sprintf` into fixed-size stack buffers (`char maps_file[32]` and `char filename[1024]`) for formatting `/proc/[pid]/maps` and `/proc/[pid]/mem` paths in `tools/vdso-transplant.c` and `tools/ptutil.c`. While PIDs are generally bounded, extreme values or logic changes could trigger a buffer overflow.
+**Learning:** Hardcoded buffer sizes combined with `sprintf` are prone to overflows if the format string inputs (like `pid`) unexpectedly exceed the allocated buffer size.
+**Prevention:** Always use `snprintf` with `sizeof(buffer)` when formatting paths or strings into fixed-size arrays to guarantee bounds checking and prevent stack corruption.

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,7 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -41,7 +41,7 @@ static void aux_write(int pid, int type, dword_t value) {
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
     char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
🚨 Severity: Low
💡 Vulnerability: Use of `sprintf` into fixed-size stack buffers when formatting process paths in `tools/ptutil.c` and `tools/vdso-transplant.c`.
🎯 Impact: Potential stack buffer overflow if a PID length unexpectedly exceeds the buffer size, leading to crashes or stack corruption.
🔧 Fix: Replaced `sprintf` with `snprintf` using `sizeof(buffer)` to guarantee bounds checking.
✅ Verification: Validated syntax by running the Meson build.

---
*PR created automatically by Jules for task [6716266451305124359](https://jules.google.com/task/6716266451305124359) started by @emkey1*