### PR TITLE
🎨 Palette: Improve accessibility of workspace selection buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-29 - Accessibility Traits Check
+**Learning:** Returning "1" or "0" for `accessibilityValue` on toggle buttons is confusing for screen reader users. Also dynamically applied styles (e.g. `workspaceApplyTheme`) and selected states should always dynamically set/unset `UIAccessibilityTraitSelected` for accessibility users.
+**Action:** Always dynamically add/remove `UIAccessibilityTraitSelected` for controls that indicate active/selected state visually in iOS apps.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -5157,6 +5157,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
             (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         _themeTitleLabelsByIdentifier[identifier].textColor = selected ? theme[@"card"] : theme[@"primary"];
         _themeDetailLabelsByIdentifier[identifier].textColor = selected ? theme[@"cardAlt"] : theme[@"secondary"];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     BOOL editingCustom = !ISHWorkspaceThemeIdentifierIsBuiltIn(_editingThemeIdentifier);
     for (UIButton *button in _editorActionButtons) {
@@ -6443,6 +6448,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)
@@ -6990,6 +7000,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
         button.layer.borderColor = (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         [button setTitleColor:(selected ? theme[@"accent"] : theme[@"primary"]) forState:UIControlStateNormal];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     _addressContainerView.backgroundColor = [theme[@"backgroundTop"] colorWithAlphaComponent:0.18];
     _addressContainerView.layer.borderColor = theme[@"stroke"].CGColor;


### PR DESCRIPTION
**💡 What:** The UX enhancement added: `UIAccessibilityTraitSelected` is dynamically applied to workspace scenes, theme buttons, and browser tabs when selected.
**🎯 Why:** The user problem it solves: Relying solely on visual changes like border width or background color is insufficient for VoiceOver users.
**📸 Before/After:** N/A (Non-visual accessibility change)
**♿ Accessibility:** VoiceOver will now explicitly announce "selected" for active workspace windows, themes, and browser tabs.

---
*PR created automatically by Jules for task [3331722491130647142](https://jules.google.com/task/3331722491130647142) started by @emkey1*