### PR TITLE
🎨 Palette: Improve accessibility of workspace scene and browser tab buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-30 - Exposing Active State for Workspace Buttons
+**Learning:** Visual indicators like background color and borders used to distinguish active/selected states of workspace buttons (e.g. browser tabs, scenes) are not explicitly communicated to VoiceOver users unless accessibility traits are updated.
+**Action:** Always dynamically apply the `UIAccessibilityTraitSelected` trait to such active UI elements, and crucially, ensure it is explicitly cleared for inactive states when buttons are reused or redrawn to provide an accurate representation for screen readers.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6443,6 +6443,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)
@@ -6990,6 +6995,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
         button.layer.borderColor = (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         [button setTitleColor:(selected ? theme[@"accent"] : theme[@"primary"]) forState:UIControlStateNormal];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     _addressContainerView.backgroundColor = [theme[@"backgroundTop"] colorWithAlphaComponent:0.18];
     _addressContainerView.layer.borderColor = theme[@"stroke"].CGColor;


### PR DESCRIPTION
**What:**
Added dynamic setting of `UIAccessibilityTraitSelected` to workspace scene buttons and browser tab buttons in `workspaceApplyTheme`.

**Why:**
Previously, visual indicators (like background color and border) indicated active states, but this information was not explicitly exposed to VoiceOver. Applying the `UIAccessibilityTraitSelected` trait to the selected elements ensures screen reader users are properly aware of their current context.

**Before/After:**
No visual changes. Accessibility traits updated based on the state.

**Accessibility:**
- Applies `UIAccessibilityTraitSelected` explicitly to selected workspace buttons and browser tab buttons.
- Removes `UIAccessibilityTraitSelected` explicitly from unselected buttons, ensuring clean recycle state.

---
*PR created automatically by Jules for task [2886619308805171942](https://jules.google.com/task/2886619308805171942) started by @emkey1*