### PR TITLE
🎨 Palette: Add accessibility selection traits to dynamic buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Dynamic Accessibility Traits on Visual State Changes
+**Learning:** In iOS, when dynamically changing the visual appearance of selection elements (such as themes, tabs, or workspaces) using background colors or borders, the selected state remains completely invisible to VoiceOver users unless explicitly communicated.
+**Action:** Always dynamically apply `UIAccessibilityTraitSelected` (`|=`) to active selection buttons and clear it (`&= ~`) for inactive ones concurrently with visual styling updates to ensure screen reader users are aware of the active selection.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -5144,6 +5144,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     for (UIButton *button in _themeSelectionButtons) {
         NSString *identifier = button.accessibilityIdentifier;
         BOOL selected = [identifier isEqualToString:ISHWorkspaceCurrentThemeIdentifier()];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = selected
             ? [theme[@"accent"] colorWithAlphaComponent:0.34]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
@@ -6439,6 +6444,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         if (button == nil)
             continue;
         BOOL current = [descriptor[@"isCurrent"] boolValue];
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = current
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
@@ -6985,6 +6995,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     }
     for (UIButton *button in _tabButtons) {
         BOOL selected = button.tag == _selectedTabIndex;
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = selected
             ? [theme[@"accent"] colorWithAlphaComponent:0.18]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];


### PR DESCRIPTION
**What:** Dynamically apply `UIAccessibilityTraitSelected` to active theme, workspace scene, and browser tab buttons, and clear it when inactive in `WorkspaceViewController.m`.
**Why:** VoiceOver users previously could not perceive the selected state of these buttons as it was only conveyed through visual styling.
**Before/After:** N/A (Non-visual change).
**Accessibility:** Significantly improves VoiceOver navigation by explicitly communicating which tab, workspace, or theme is currently active.

---
*PR created automatically by Jules for task [2903378593551211104](https://jules.google.com/task/2903378593551211104) started by @emkey1*