### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix buffer overflows in tool process paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-03-27 - Buffer Overflow in Tool Process Paths
+**Vulnerability:** `tools/ptutil.c` and `tools/vdso-transplant.c` used `sprintf` with fixed-size local buffers (`char filename[1024]` and `char maps_file[32]`) to construct `/proc/<pid>/...` paths. Unchecked PIDs could potentially overflow these stack buffers, especially the 32-byte one.
+**Learning:** Even internal tool scripts that seem insulated must properly bound dynamic string formatting involving process IDs to avoid hard-to-diagnose stack smashes or security escalations.
+**Prevention:** Always use `snprintf(buf, sizeof(buf), ...)` instead of `sprintf` when generating path strings dynamically, and ensure buffer size is sufficient (e.g. `MAX_PATH` or at least 64 bytes for process path generation).

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,7 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -41,7 +41,7 @@ static void aux_write(int pid, int type, dword_t value) {
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
     char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
- **Severity**: MEDIUM
- **Vulnerability**: Unsafe `sprintf` into fixed-size stack buffers (`char filename[1024]` and `char maps_file[32]`) for `/proc/<pid>` paths.
- **Impact**: Large or malformed PIDs could overflow the stack buffers, potentially leading to memory corruption or crashes.
- **Fix**: Replaced `sprintf` with `snprintf` to enforce explicit buffer limits based on `sizeof()` in `tools/ptutil.c` and `tools/vdso-transplant.c`.
- **Verification**: Built the tools.

---
*PR created automatically by Jules for task [5802672858109749174](https://jules.google.com/task/5802672858109749174) started by @emkey1*