### PR TITLE
⚡ Bolt: Avoid recalculating string length in tmpfs_getpath

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2026-03-25 - Hoist string length calculations in VFS inner functions
 **Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
 **Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.
+## 2026-03-25 - Avoid recalculating string length in tmpfs_getpath
+**Learning:** In `fs/tmp.c`, `tmpfs_getpath` repeatedly appended path components from a bottom-up directory traversal, and then called `strlen(p)` to find the total length for the final `memmove`. This forces an unnecessary O(N) string traversal when the component lengths are already known and accumulated during the loop.
+**Action:** Replace `strlen(p)` with a running `total_len` counter in `tmpfs_getpath` that accumulates the lengths of the directory components to prevent redundant string traversals.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -582,6 +582,7 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
     struct tmp_dirent *root_dirent = fd->mount->data;
     char *p = buf + MAX_PATH - 1;
     *p = '\0';
+    size_t total_len = 0;
     while (dirent != root_dirent) {
         size_t name_len = strlen(dirent->name);
         p -= name_len + 1;
@@ -590,8 +591,9 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         p[0] = '/';
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
+        total_len += name_len + 1;
     }
-    memmove(buf, p, strlen(p) + 1);
+    memmove(buf, p, total_len + 1);
     return 0;
 }
 


### PR DESCRIPTION
**What:** Replaced the `strlen(p)` call in `tmpfs_getpath` with a pre-calculated `total_len` that accumulates during the directory traversal.
**Why:** The original code forced an unnecessary O(N) string traversal to find the length of the string for the final `memmove`, even though the exact component lengths were already known and could be tracked during the loop.
**Impact:** Eliminates a redundant O(N) string calculation, providing a small but consistent performance improvement during tmpfs path resolution.
**Measurement:** The change was verified by running the e2e test suite, and performance can be measured by profiling tmpfs path resolution (e.g. `getcwd` or `readlink` in a tmpfs mount).

---
*PR created automatically by Jules for task [8122760609669933522](https://jules.google.com/task/8122760609669933522) started by @emkey1*