### PR TITLE
🎨 Palette: Add accessibility traits for active tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Explicit Accessibility Traits for Dynamic Styling
+**Learning:** When dynamically changing the visual appearance of selection elements (like themes, tabs, or workspaces) using background colors or borders, the selected state remains invisible to VoiceOver users unless explicitly communicated.
+**Action:** Always dynamically apply `UIAccessibilityTraitSelected` (`|=`) to active selection buttons and clear it (`&= ~`) for inactive ones concurrently with visual styling updates (e.g., in `workspaceApplyTheme`).

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6990,6 +6990,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
         button.layer.borderColor = (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         [button setTitleColor:(selected ? theme[@"accent"] : theme[@"primary"]) forState:UIControlStateNormal];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
     }
     _addressContainerView.backgroundColor = [theme[@"backgroundTop"] colorWithAlphaComponent:0.18];
     _addressContainerView.layer.borderColor = theme[@"stroke"].CGColor;


### PR DESCRIPTION
💡 **What:** Added `UIAccessibilityTraitSelected` to the currently active tab button in `workspaceApplyTheme` within `WorkspaceViewController.m`.
🎯 **Why:** Previously, the active tab was only indicated visually via a background color and border change. VoiceOver users would not hear which tab was selected, causing confusion when navigating the workspace tool.
📸 **Before/After:** N/A (Non-visual change)
♿ **Accessibility:** Screen readers now accurately announce the selected tab by reading "selected" when focusing on the active tab button.

---
*PR created automatically by Jules for task [8541247356512506395](https://jules.google.com/task/8541247356512506395) started by @emkey1*