### PR TITLE
⚡ Bolt: Optimize path construction in tmpfs_getpath

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,7 @@
 ## 2026-03-25 - Hoist string length calculations in VFS inner functions
 **Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
 **Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.
+
+## 2026-03-26 - Eliminate redundant string traversals in backwards path construction
+**Learning:** In iSH VFS path construction functions (e.g., `tmpfs_getpath`), paths are often built backwards from the end of a fixed-size buffer. Calling `strlen()` on the resulting pointer after the loop causes an unnecessary O(N) traversal of the newly constructed string.
+**Action:** When building a path string backwards, accumulate the length dynamically inside the loop. This provides the exact string length for operations like `memmove` in O(1) time, eliminating the redundant O(N) traversal.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -581,17 +581,19 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
     struct tmp_dirent *dirent = fd->tmpfs.dirent;
     struct tmp_dirent *root_dirent = fd->mount->data;
     char *p = buf + MAX_PATH - 1;
+    size_t path_len = 0;
     *p = '\0';
     while (dirent != root_dirent) {
         size_t name_len = strlen(dirent->name);
         p -= name_len + 1;
         if (p < buf)
             return _ENAMETOOLONG;
+        path_len += name_len + 1;
         p[0] = '/';
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    memmove(buf, p, path_len + 1);
     return 0;
 }
 


### PR DESCRIPTION
**What:** 
Replaced the `strlen(p)` call at the end of `tmpfs_getpath` with a dynamically accumulated `path_len` variable. 

**Why:** 
When building a path string backwards from the end of a fixed-size buffer (`buf + MAX_PATH - 1`), the length of the string is computed inherently as each directory component is prepended. Using `strlen()` on the resulting pointer after the loop forces an unnecessary O(N) traversal of the newly constructed string just to find its length for the final `memmove`. 

**Impact:** 
Changes the final length calculation from O(N) to O(1) by maintaining the length during the loop, saving CPU cycles on `memmove` calls when paths are constructed for tmpfs.

**Measurement:** 
Run Meson build and execute `./tests/e2e/e2e.bash` to ensure the correct path resolution is maintained. The change is deterministic and algorithmic, so the performance gain scales with the length of the requested paths in tmpfs.

---
*PR created automatically by Jules for task [8816971876231686821](https://jules.google.com/task/8816971876231686821) started by @emkey1*