### PR TITLE
🎨 Palette: Add accessibility label to workspace close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-29 - Close Button Accessibility
+**Learning:** Icon-only buttons or buttons with non-standard text (like "×") need descriptive `accessibilityLabel` properties so that VoiceOver announces them correctly instead of reading out the symbol or character literally.
+**Action:** Always add an `accessibilityLabel` to buttons whose visual text or icon isn't sufficiently descriptive for a screen reader.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -227,6 +227,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
+    self.closeButton.accessibilityLabel = @"Close";
     self.closeButton.hidden = !showsCloseButton;
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
     self.closeButton.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.82];


### PR DESCRIPTION
**What:** Added an `accessibilityLabel` to the close button in workspace windows.
**Why:** The close button currently just has "×" as its visual text. For screen readers, this might be announced as "multiplication sign" or just "button" without context, leading to poor UX for VoiceOver users.
**Before/After:** No visual change. VoiceOver will now announce "Close, button" instead of the literal character.
**Accessibility:** Enhanced screen reader support by providing a clear, descriptive label for the window closing action.

---
*PR created automatically by Jules for task [9252078057880004599](https://jules.google.com/task/9252078057880004599) started by @emkey1*