### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace unsafe sprintf with snprintf in tools directory

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,7 +32,7 @@
 **Vulnerability:** `fs/real.c` used a 20-byte buffer for formatting `/proc/self/fd/%d`, but the path prefix is 14 bytes and a 32-bit signed int can be 11 bytes, requiring at least 26 bytes. This allows a stack buffer overflow for very large file descriptors.
 **Learning:** Hardcoded buffer sizes for path formatting often fail to account for the maximum string length of integers.
 **Prevention:** Always allocate at least 32 bytes for paths containing PIDs or FDs, and consider using `snprintf` to avoid overflow entirely.
-## $(date +%Y-%m-%d) - Replace unsafe strcpy calls with strncpy in fs/tmp.c
+## 2026-05-20 - Replace unsafe strcpy calls with strncpy in fs/tmp.c
 **Vulnerability:** Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[MAX_NAME + 1]`) in `fs/tmp.c`.
 **Learning:** Legacy VFS and temporary filesystem code often lacks explicit bounds checking, relying on higher-level path validation. This creates defense-in-depth vulnerabilities if `MAX_NAME` bounds are ever exceeded.
 **Prevention:** Always use `strncpy` and manually ensure null-termination for fixed-size string arrays in the kernel, regardless of upstream path validation.
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-05-20 - Buffer Overflow Risk in PID Path Formatting
+**Vulnerability:** Fixed-size buffers (`char maps_file[32]`) were populated using `sprintf` without bounds checking in `tools/vdso-transplant.c` and `tools/ptutil.c` when constructing paths like `/proc/%d/maps`.
+**Learning:** Even though `pid_t` typically fits within standard limits, relying on `sprintf` into fixed-size stack arrays without explicit bounds checking is an insecure pattern prone to regressions.
+**Prevention:** Always use `snprintf` with `sizeof(buffer)` for dynamically generated paths to enforce hard limits and prevent silent buffer overflows.

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,8 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    // SECURITY: Use snprintf instead of sprintf to enforce strict buffer boundaries and prevent overflow
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -41,7 +41,8 @@ static void aux_write(int pid, int type, dword_t value) {
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
     char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    // SECURITY: Use snprintf instead of sprintf to enforce strict buffer boundaries and prevent overflow
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Fixed-size stack buffers were used with `sprintf` when generating path strings `/proc/%d/mem` and `/proc/%d/maps` in the tools directory. If `pid` values somehow exceeded expected boundaries or paths changed format, this could lead to buffer overflows.
🎯 Impact: Prevents potential buffer overflows when handling process identifiers in path formatting operations within development and diagnostic tools.
🔧 Fix: Replaced `sprintf(buf, ...)` with `snprintf(buf, sizeof(buf), ...)` and added inline security comments in `tools/ptutil.c` and `tools/vdso-transplant.c` to enforce strict buffer boundaries.
✅ Verification: Ran `tools/` compilation via E2E testing to ensure the formatting operates safely and cleanly.

---
*PR created automatically by Jules for task [360781291149689600](https://jules.google.com/task/360781291149689600) started by @emkey1*