### PR TITLE
⚡ Bolt: Optimize `tmpfs_getpath` string length tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2026-03-25 - Hoist string length calculations in VFS inner functions
 **Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
 **Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.
+## 2024-05-27 - Optimize string length in backward path construction
+**Learning:** In VFS path construction functions (e.g., `tmpfs_getpath`), when building a path string backwards from the end of a buffer, calling `strlen()` on the resulting pointer causes a redundant O(N) traversal.
+**Action:** Accumulate the length dynamically inside the loop to eliminate the redundant `strlen()` call, making the final length lookup an O(1) operation.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -581,17 +581,19 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
     struct tmp_dirent *dirent = fd->tmpfs.dirent;
     struct tmp_dirent *root_dirent = fd->mount->data;
     char *p = buf + MAX_PATH - 1;
+    size_t n = 0;
     *p = '\0';
     while (dirent != root_dirent) {
         size_t name_len = strlen(dirent->name);
         p -= name_len + 1;
         if (p < buf)
             return _ENAMETOOLONG;
+        n += name_len + 1;
         p[0] = '/';
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    memmove(buf, p, n + 1);
     return 0;
 }
 


### PR DESCRIPTION
💡 **What:** Tracks the path length directly in a variable (`n`) inside `tmpfs_getpath` instead of calling `strlen` at the end.
🎯 **Why:** In VFS path reconstruction functions, building strings backwards is common, but calling `strlen` on the resulting string causes unnecessary O(N) recalculations of loop-invariant bounds.
📊 **Impact:** Replaces a linear O(N) `strlen` lookup with a constant O(1) memory size passed to `memmove`.
🔬 **Measurement:** Code logic continues to correctly calculate memory boundaries during path assembly, matching the previous functional behavior. Reviewed and passed E2E tests `shell`, `sse2`, and `utimens_symlink`.

---
*PR created automatically by Jules for task [12121085150849948726](https://jules.google.com/task/12121085150849948726) started by @emkey1*