### PR TITLE
🎨 Palette: Add ARIA labels to icon-only close/tab buttons

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -226,6 +226,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
+    self.closeButton.accessibilityLabel = @"Close";
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
     self.closeButton.hidden = !showsCloseButton;
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
@@ -6650,7 +6651,9 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _goButton = [self browserButtonWithTitle:@"Go" action:@selector(commitAddress:)];
     _addTabButton = [self browserButtonWithTitle:@"+" action:@selector(addTab:)];
+    _addTabButton.accessibilityLabel = @"New Tab";
     _closeTabButton = [self browserButtonWithTitle:@"×" action:@selector(closeCurrentTab:)];
+    _closeTabButton.accessibilityLabel = @"Close Tab";
     UILongPressGestureRecognizer *homeLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleHomeButtonLongPress:)];
     homeLongPressRecognizer.minimumPressDuration = 0.35;


### PR DESCRIPTION
💡 What: Added `accessibilityLabel` properties to icon-only buttons in `WorkspaceViewController.m`.
🎯 Why: To ensure screen readers announce the function of the buttons (e.g. "Close", "New Tab", "Close Tab") instead of their literal text symbols (e.g. "times", "plus"), vastly improving the user experience for VoiceOver users.
📸 Before/After: Visuals are identical.
♿ Accessibility: The `closeButton`, `_addTabButton`, and `_closeTabButton` now have proper VoiceOver labels.

---
*PR created automatically by Jules for task [12165409993890167114](https://jules.google.com/task/12165409993890167114) started by @emkey1*