### PR TITLE
🎨 Palette: Indicate selected theme to VoiceOver users

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-29 - Accessibility Traits for Custom Selection Elements
+**Learning:** In iOS UI development, when dynamically changing the visual appearance of custom selection elements (like theme buttons) to indicate selection (e.g., using borders, background colors, or shadows), this visual state is invisible to VoiceOver.
+**Action:** Always dynamically apply `UIAccessibilityTraitSelected` (`|=`) to active selection buttons and clear it (`&= ~`) for inactive ones concurrently with visual styling updates.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -5153,6 +5153,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
         button.layer.shadowOpacity = selected ? 0.35 : 0.0;
         button.layer.shadowRadius = selected ? 10.0 : 0.0;
         button.layer.shadowOffset = CGSizeMake(0, 0);
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         _themePreviewImageViewsByIdentifier[identifier].layer.borderColor =
             (selected ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
         _themeTitleLabelsByIdentifier[identifier].textColor = selected ? theme[@"card"] : theme[@"primary"];


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` to active theme selection buttons and cleared it for inactive ones in `WorkspaceThemesToolViewController`.
🎯 Why: The selected theme was only indicated visually (via border, shadow, and background color), making it invisible to screen readers.
📸 Before/After: Visuals are unchanged; VoiceOver now correctly announces which theme button is selected.
♿ Accessibility: Screen reader users can now determine the currently active theme.

---
*PR created automatically by Jules for task [8029968062943237120](https://jules.google.com/task/8029968062943237120) started by @emkey1*