### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix buffer overflow in process path formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-03-27 - Buffer Overflow DoS in Process Paths
+**Vulnerability:** Fixed-size buffers were used with `sprintf` in `tools/ptutil.c` and `tools/vdso-transplant.c` to format process-related paths (`/proc/[pid]/...`).
+**Learning:** Relying on `sprintf` to format process-related paths into fixed-size buffers introduces buffer overflow risks, especially as PID lengths or path formats might change.
+**Prevention:** Always use `snprintf` with `sizeof(buffer)` when formatting paths into fixed-size character arrays to enforce boundary limits.

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,7 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -41,7 +41,7 @@ static void aux_write(int pid, int type, dword_t value) {
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
     char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unsafe use of `sprintf` into fixed-size stack buffers (`char filename[1024]` and `char maps_file[32]`) when formatting process paths (`/proc/[pid]/mem` and `/proc/[pid]/maps`).
🎯 **Impact:** Potential stack buffer overflow leading to DoS or memory corruption if PIDs or path lengths unexpectedly exceed buffer bounds.
🔧 **Fix:** Replaced `sprintf` with bounds-checked `snprintf` using `sizeof(buffer)`.
✅ **Verification:** Verified successful compilation of affected tools (`ptutil.c` and `vdso-transplant.c`) and ran standard test suite.

---
*PR created automatically by Jules for task [5879743602333547288](https://jules.google.com/task/5879743602333547288) started by @emkey1*