### PR TITLE
🎨 Palette: Add accessibility label to Workspace window close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Non-standard Textual Symbols Accessibility
+**Learning:** Buttons using non-standard textual symbols (e.g., '×' for close) or icon-only buttons will be announced literally by VoiceOver (e.g., "multiply") unless explicitly labeled.
+**Action:** Always explicitly set `accessibilityLabel` on icon-only buttons or buttons using non-standard textual symbols to ensure VoiceOver announces their function correctly.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -226,6 +226,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
+    self.closeButton.accessibilityLabel = @"Close";
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
     self.closeButton.hidden = !showsCloseButton;
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;


### PR DESCRIPTION
💡 What: Added `accessibilityLabel = @"Close"` to the workspace window close button.
🎯 Why: The button uses the non-standard textual symbol "×". Without an explicit label, VoiceOver announces the literal symbol ("multiply" or "times") instead of the button's function.
📸 Before/After: Visuals are unchanged.
♿ Accessibility: VoiceOver now accurately reads "Close" for this button instead of "multiply".

A new entry was also added to `.jules/palette.md` to document this learning.

---
*PR created automatically by Jules for task [14059344477599827590](https://jules.google.com/task/14059344477599827590) started by @emkey1*