### PR TITLE
🎨 Palette: Add accessibility labels to workspace window buttons

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -225,6 +225,8 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
 
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.closeButton.accessibilityLabel = @"Close window";
+    self.closeButton.accessibilityHint = @"Closes this workspace window.";
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
     self.closeButton.hidden = !showsCloseButton;
@@ -236,6 +238,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
 
     self.utilityButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.utilityButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.utilityButton.accessibilityLabel = @"Window options";
     self.utilityButton.hidden = YES;
     self.utilityButton.alpha = 0.0;
     self.utilityButton.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.82];


### PR DESCRIPTION
💡 What: Added `accessibilityLabel` and `accessibilityHint` to the `closeButton` and `utilityButton` in `WorkspaceViewController.m`.
🎯 Why: The `closeButton` uses a non-standard text symbol ("×") that VoiceOver reads literally as "times" or "multiply". The `utilityButton` is icon-only. Adding explicit accessibility labels ensures screen reader users can accurately understand these buttons' purposes.
♿ Accessibility: Improved VoiceOver experience for workspace window management controls by providing clear, descriptive labels and hints instead of relying on literal character reading.

---
*PR created automatically by Jules for task [3228704179990122744](https://jules.google.com/task/3228704179990122744) started by @emkey1*