### PR TITLE
🎨 Palette: Add accessibilityLabels to Workspace buttons

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -227,6 +227,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
+    self.closeButton.accessibilityLabel = @"Close";
     self.closeButton.hidden = !showsCloseButton;
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
     self.closeButton.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.82];
@@ -6482,6 +6483,19 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
 - (UIButton *)browserButtonWithTitle:(NSString *)title action:(SEL)action {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.translatesAutoresizingMaskIntoConstraints = NO;
+    if ([title isEqualToString:@"<"]) {
+        button.accessibilityLabel = @"Back";
+    } else if ([title isEqualToString:@">"]) {
+        button.accessibilityLabel = @"Forward";
+    } else if ([title isEqualToString:@"R"]) {
+        button.accessibilityLabel = @"Reload";
+    } else if ([title isEqualToString:@"+"]) {
+        button.accessibilityLabel = @"New Tab";
+    } else if ([title isEqualToString:@"×"]) {
+        button.accessibilityLabel = @"Close Tab";
+    } else {
+        button.accessibilityLabel = title;
+    }
     button.layer.cornerRadius = 10.0;
     button.layer.borderWidth = 1.0;
     button.titleLabel.font = [UIFont systemFontOfSize:ISHWorkspaceThemeFontSize(UIFontTextStyleFootnote)
@@ -6798,6 +6812,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _closeTabButton.enabled = _tabWebViews.count > 1;
     _closeTabButton.alpha = _closeTabButton.enabled ? 1.0 : 0.42;
     [_reloadButton setTitle:(currentWebView.loading ? @"X" : @"R") forState:UIControlStateNormal];
+    _reloadButton.accessibilityLabel = currentWebView.loading ? @"Stop Loading" : @"Reload";
     _progressView.hidden = !currentWebView.loading && currentWebView.estimatedProgress >= 0.999;
     _progressView.alpha = _progressView.hidden ? 0.0 : 1.0;
     if (!_addressField.isFirstResponder) {


### PR DESCRIPTION
### 💡 What
Added `accessibilityLabel` properties to several `UIButton` elements in `WorkspaceViewController.m` that rely on text symbols (like `×`, `<`, `>`, `R`, `+`) for their visual appearance instead of descriptive text.

### 🎯 Why
VoiceOver and other assistive technologies often interpret text symbols literally (e.g., reading `×` as "multiplication sign" or `<` as "less than"). By explicitly setting the `accessibilityLabel` to descriptive terms like "Close", "Back", or "Reload", we ensure the UI is fully accessible and intuitive for users relying on screen readers. 

### 📸 Before/After
**Before:**
* Close button read as "multiplication sign"
* Browser back button read as "less than"
* Reload button read as "R" or "X" without indicating its actual function.

**After:**
* Close button reads as "Close"
* Browser buttons read as "Back", "Forward", "Reload", "New Tab", and "Close Tab"
* The Reload button dynamically reads as "Stop Loading" when a page is actively loading.

### ♿ Accessibility
*   Added `"Close"` label to the window close button.
*   Added labels for standard browser navigation controls.
*   Added dynamic state support for the reload/stop button based on `currentWebView.loading`.

---
*PR created automatically by Jules for task [4287965321163553355](https://jules.google.com/task/4287965321163553355) started by @emkey1*