### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflows via sprintf

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-05-25 - Buffer Overflows from sprintf
+**Vulnerability:** Unbounded string copies via `sprintf` in multiple components (like `emu/regid.h`, `fs/pty.c`, `fs/proc/pid.c`, `fs/proc/root.c`, `fs/sock.c`, `tools/ptutil.c`, and `tools/vdso-transplant.c`) when writing to fixed-size char arrays.
+**Learning:** The usage of `sprintf` without length bounds check can lead to buffer overflows when dynamically generating strings from potentially uncontrolled input (e.g. process IDs or string templates). This continues to be a systemic issue resulting in technical debt.
+**Prevention:** Always replace `sprintf` with `snprintf` and provide the correct buffer size to ensure memory safety bounds checking. Always verify bounds explicitly.

--- a/emu/regid.h
+++ b/emu/regid.h
@@ -60,7 +60,7 @@ struct regptr {
 };
 static __attribute__((unused)) const char *regptr_name(struct regptr regptr) {
     static char buf[15];
-    sprintf(buf, "%s/%s/%s",
+    snprintf(buf, sizeof(buf), "%s/%s/%s",
             regid8_name(regptr.reg8_id),
             regid16_name(regptr.reg16_id),
             regid32_name(regptr.reg32_id));

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -19,7 +19,7 @@ extern dword_t extra_lock_pid;
 extern const char extra_lock_comm;
 
 static void proc_pid_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->pid);
+    snprintf(buf, MAX_NAME + 1, "%d", entry->pid);
 }
 
 static char proc_task_state_char(struct task *task) {
@@ -595,7 +595,7 @@ static bool proc_pid_fd_readdir(struct proc_entry *entry, unsigned long *index, 
 }
 
 static void proc_pid_fd_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->fd);
+    snprintf(buf, MAX_NAME + 1, "%d", entry->fd);
 }
 
 static bool proc_pid_fdinfo_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
@@ -697,7 +697,7 @@ static int proc_pid_exe_readlink(struct proc_entry *entry, char *buf) {
 }
 
 static void proc_pid_task_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->pid);
+    snprintf(buf, MAX_NAME + 1, "%d", entry->pid);
 }
 
 static struct proc_dir_entry proc_pid_task;

--- a/fs/proc/root.c
+++ b/fs/proc/root.c
@@ -352,7 +352,7 @@ static int proc_show_loadavg(struct proc_entry *UNUSED(entry), struct proc_data 
 }
 
 static int proc_readlink_self(struct proc_entry *UNUSED(entry), char *buf) {
-    sprintf(buf, "%d/", current->pid);
+    snprintf(buf, MAX_PATH, "%d/", current->pid);
     return 0;
 }
 
@@ -871,7 +871,7 @@ static int sysfs_getpath(struct fd *fd, char *buf) {
             strcpy(buf, "/devices/system/cpu/offline");
             break;
         case sysfs_cpu_dir:
-            sprintf(buf, "/devices/system/cpu/cpu%d", node.cpu);
+            snprintf(buf, MAX_PATH, "/devices/system/cpu/cpu%d", node.cpu);
             break;
     }
     return 0;

--- a/fs/pty.c
+++ b/fs/pty.c
@@ -203,7 +203,7 @@ static int devpts_getpath(struct fd *fd, char *buf) {
     if (fd->devpts.num == -1)
         memcpy(buf, "", 1);
     else
-        sprintf(buf, "/%d", fd->devpts.num);
+        snprintf(buf, MAX_PATH, "/%d", fd->devpts.num);
     return 0;
 }
 
@@ -292,7 +292,7 @@ static int devpts_readdir(struct fd *fd, struct dir_entry *entry) {
     if (pty_num >= MAX_PTYS)
         return 0;
     fd->offset = pty_num + 1;
-    sprintf(entry->name, "%d", pty_num);
+    snprintf(entry->name, sizeof(entry->name), "%d", pty_num);
     entry->inode = pty_num + 3;
     entry->type = DT_CHR;
    // if (minor == DEV_PTMX_MINOR) 

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -2064,7 +2064,8 @@ static int sockaddr_read_bind(guest_addr_t sockaddr_addr, void *sockaddr, uint_t
             }
 
             struct sockaddr_un *real_addr_un = sockaddr;
-            size_t path_len = sprintf(real_addr_un->sun_path, "%s.%u", sock_tmp_prefix, socket_id);
+            size_t path_len = snprintf(real_addr_un->sun_path, sizeof(real_addr_un->sun_path), "%s.%u", sock_tmp_prefix, socket_id);
+            if (path_len >= sizeof(real_addr_un->sun_path)) return _ENAMETOOLONG;
 #ifdef __APPLE__
             real_addr_un->sun_len = offsetof(struct sockaddr_un, sun_path) + path_len;
 #endif

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,7 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -41,7 +41,7 @@ static void aux_write(int pid, int type, dword_t value) {
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
     char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** Unbounded string copying via `sprintf` across multiple files when writing to fixed-size char arrays (`emu/regid.h`, `fs/pty.c`, `fs/proc/pid.c`, `fs/proc/root.c`, `fs/sock.c`, `tools/ptutil.c`, `tools/vdso-transplant.c`).
**Impact:** A potential stack buffer overflow could occur if a path, PID, socket name, or format string exceeded the hardcoded limits of the static or stack-allocated buffers. This is especially risky where user input or dynamically allocated PIDs/FDs could influence the string size.
**Fix:** Replaced all vulnerable `sprintf` occurrences with `snprintf`, applying explicit bounds checks using `sizeof()`, `MAX_PATH`, or `MAX_NAME + 1`. Added truncation handling for `sun_path` generation in `fs/sock.c` returning `_ENAMETOOLONG`.
**Verification:** Code compiled and E2E test suite correctly executed with no newly introduced regressions. Tested correct translation logic locally within bounds.

---
*PR created automatically by Jules for task [5807958553130173526](https://jules.google.com/task/5807958553130173526) started by @emkey1*