### PR TITLE
⚡ Bolt: Optimize tmpfs_getpath string length calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,7 @@
 ## 2026-03-25 - Hoist string length calculations in VFS inner functions
 **Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
 **Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.
+
+## 2026-05-25 - Avoid strlen in backward string construction
+**Learning:** In VFS path construction functions (e.g., `tmpfs_getpath`), when building a path string backwards from the end of a buffer, calling `strlen()` on the resulting pointer introduces an unnecessary O(N) string traversal. The length can be computed in O(1) time using pointer arithmetic (e.g., `(buf + MAX_PATH) - p`).
+**Action:** Replace `strlen(p)` with `(buf + MAX_PATH) - p` (or equivalent pointer arithmetic based on buffer boundaries) to compute lengths when constructing strings backwards to avoid performance degradation.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -591,7 +591,8 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    // Bolt: Compute length in O(1) instead of using strlen(p)
+    memmove(buf, p, (buf + MAX_PATH) - p);
     return 0;
 }
 


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced `strlen(p)` with pointer arithmetic `(buf + MAX_PATH) - p` when calculating the final string length in `tmpfs_getpath`.

🎯 Why: The performance problem it solves
When constructing a filesystem path backwards from the end of a buffer, the resulting pointer `p` points to the start of the string, while the end of the string is guaranteed to be at `buf + MAX_PATH - 1`. Calling `strlen(p)` to determine the string length causes an unnecessary O(N) traversal of the buffer. 

📊 Impact: Expected performance improvement
Reduces redundant O(N) string traversals in VFS path formatting. Length calculation becomes O(1).

🔬 Measurement: How to verify the improvement
Inspect `fs/tmp.c` to verify `tmpfs_getpath` uses `memmove(buf, p, (buf + MAX_PATH) - p);` and runs correctly under load. Tested via E2E test suite.

---
*PR created automatically by Jules for task [16478052762838109438](https://jules.google.com/task/16478052762838109438) started by @emkey1*