### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflows caused by sprintf usage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2024-03-26 - Buffer Overflow via unsafe sprintf formatting
+**Vulnerability:** Unbounded string formatting using `sprintf` throughout the codebase (e.g. `fs/pty.c`, `fs/sock.c`, `fs/proc/root.c`). This poses a buffer overflow risk if dynamic values like PIDs, socket IDs, or devpts numbers somehow exceed anticipated constraints.
+**Learning:** Legacy codebase patterns often use `sprintf` out of convenience, implicitly trusting that dynamic components will always be small enough to fit within static buffer boundaries.
+**Prevention:** Always replace `sprintf` with the bounds-checked `snprintf`. Validate the return value (which is the number of characters that would have been written) to safely detect and handle truncation conditions (e.g., returning `_ENAMETOOLONG`) rather than risking memory corruption or silent path truncation.

--- a/emu/regid.h
+++ b/emu/regid.h
@@ -60,7 +60,7 @@ struct regptr {
 };
 static __attribute__((unused)) const char *regptr_name(struct regptr regptr) {
     static char buf[15];
-    sprintf(buf, "%s/%s/%s",
+    snprintf(buf, sizeof(buf), "%s/%s/%s",
             regid8_name(regptr.reg8_id),
             regid16_name(regptr.reg16_id),
             regid32_name(regptr.reg32_id));

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -19,7 +19,7 @@ extern dword_t extra_lock_pid;
 extern const char extra_lock_comm;
 
 static void proc_pid_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->pid);
+    snprintf(buf, MAX_NAME, "%d", entry->pid);
 }
 
 static char proc_task_state_char(struct task *task) {
@@ -595,7 +595,7 @@ static bool proc_pid_fd_readdir(struct proc_entry *entry, unsigned long *index, 
 }
 
 static void proc_pid_fd_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->fd);
+    snprintf(buf, MAX_NAME, "%d", entry->fd);
 }
 
 static bool proc_pid_fdinfo_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
@@ -697,7 +697,7 @@ static int proc_pid_exe_readlink(struct proc_entry *entry, char *buf) {
 }
 
 static void proc_pid_task_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->pid);
+    snprintf(buf, MAX_NAME, "%d", entry->pid);
 }
 
 static struct proc_dir_entry proc_pid_task;

--- a/fs/proc/root.c
+++ b/fs/proc/root.c
@@ -352,7 +352,8 @@ static int proc_show_loadavg(struct proc_entry *UNUSED(entry), struct proc_data 
 }
 
 static int proc_readlink_self(struct proc_entry *UNUSED(entry), char *buf) {
-    sprintf(buf, "%d/", current->pid);
+    if (snprintf(buf, MAX_PATH, "%d/", current->pid) >= MAX_PATH)
+        return _ENAMETOOLONG;
     return 0;
 }
 
@@ -871,7 +872,8 @@ static int sysfs_getpath(struct fd *fd, char *buf) {
             strcpy(buf, "/devices/system/cpu/offline");
             break;
         case sysfs_cpu_dir:
-            sprintf(buf, "/devices/system/cpu/cpu%d", node.cpu);
+            if (snprintf(buf, MAX_PATH, "/devices/system/cpu/cpu%d", node.cpu) >= MAX_PATH)
+                return _ENAMETOOLONG;
             break;
     }
     return 0;

--- a/fs/pty.c
+++ b/fs/pty.c
@@ -202,8 +202,11 @@ static struct fd *devpts_open(struct mount *UNUSED(mount), const char *path, int
 static int devpts_getpath(struct fd *fd, char *buf) {
     if (fd->devpts.num == -1)
         memcpy(buf, "", 1);
-    else
-        sprintf(buf, "/%d", fd->devpts.num);
+    else {
+        int len = snprintf(buf, MAX_PATH, "/%d", fd->devpts.num);
+        if (len >= MAX_PATH)
+            return _ENAMETOOLONG;
+    }
     return 0;
 }
 
@@ -292,7 +295,7 @@ static int devpts_readdir(struct fd *fd, struct dir_entry *entry) {
     if (pty_num >= MAX_PTYS)
         return 0;
     fd->offset = pty_num + 1;
-    sprintf(entry->name, "%d", pty_num);
+    snprintf(entry->name, sizeof(entry->name), "%d", pty_num);
     entry->inode = pty_num + 3;
     entry->type = DT_CHR;
    // if (minor == DEV_PTMX_MINOR) 

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -2064,7 +2064,9 @@ static int sockaddr_read_bind(guest_addr_t sockaddr_addr, void *sockaddr, uint_t
             }
 
             struct sockaddr_un *real_addr_un = sockaddr;
-            size_t path_len = sprintf(real_addr_un->sun_path, "%s.%u", sock_tmp_prefix, socket_id);
+            size_t path_len = snprintf(real_addr_un->sun_path, sizeof(real_addr_un->sun_path), "%s.%u", sock_tmp_prefix, socket_id);
+            if (path_len >= sizeof(real_addr_un->sun_path))
+                return _ENAMETOOLONG;
 #ifdef __APPLE__
             real_addr_un->sun_len = offsetof(struct sockaddr_un, sun_path) + path_len;
 #endif

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,7 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -41,7 +41,7 @@ static void aux_write(int pid, int type, dword_t value) {
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
     char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
Replaced unsafe instances of `sprintf` with `snprintf` across the codebase to prevent potential buffer overflows. Added checks to correctly return `_ENAMETOOLONG` where applicable if paths exceed predefined boundaries (e.g. `MAX_PATH` or `MAX_NAME`). Also documented the findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11592048109721205872](https://jules.google.com/task/11592048109721205872) started by @emkey1*