### PR TITLE
⚡ Bolt: Optimize tmpfs_getpath length calculation via pointer arithmetic

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,7 @@
 ## 2026-03-25 - Hoist string length calculations in VFS inner functions
 **Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
 **Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.
+
+## 2026-03-25 - Avoid strlen when constructing backwards
+**Learning:** When building a string dynamically from the end of a buffer backwards (e.g., in `tmpfs_getpath`), using `strlen()` to find the length at the end causes redundant O(N) calculation. The exact length is already determinable via pointer arithmetic.
+**Action:** Replace `strlen(p) + 1` with `(buf + MAX_PATH) - p` when the buffer boundaries and current string pointer are known, to achieve an O(1) length calculation.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -591,7 +591,8 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    // Bolt: O(1) length calculation via pointer arithmetic instead of O(N) strlen()
+    memmove(buf, p, (buf + MAX_PATH) - p);
     return 0;
 }
 


### PR DESCRIPTION
**💡 What:** 
Replaced an O(N) `strlen(p) + 1` calculation with an O(1) pointer arithmetic calculation `(buf + MAX_PATH) - p` at the end of `tmpfs_getpath` in `fs/tmp.c`. Added an inline comment explaining the optimization.

**🎯 Why:** 
When dynamically building a string from the end of a buffer backwards, the distance from the current string pointer (`p`) to the absolute end of the buffer (`buf + MAX_PATH`) perfectly represents the length of the string, including the pre-placed null terminator. Calling `strlen()` on this string causes an unnecessary O(N) traversal of memory that we already just computed.

**📊 Impact:** 
Reduces algorithmic complexity of the final string size calculation in `tmpfs_getpath` from O(N) to O(1), improving micro-performance during path operations without sacrificing memory safety (as it explicitly relies on the known `MAX_PATH` buffer boundaries).

**🔬 Measurement:** 
Run `./tests/e2e/e2e.bash` (with appropriate dependencies installed) to verify path logic is not broken. Since this is a micro-optimization on VFS logic within a test runner wrapper, system-level benchmarking or profiling against `tmpfs_getpath` specifically would confirm the reduction in loop traversals.

---
*PR created automatically by Jules for task [11534719975697079463](https://jules.google.com/task/11534719975697079463) started by @emkey1*