### PR TITLE
🎨 Palette: Add accessibility labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,6 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+## 2024-05-29 - Contextual Accessibility Labels for Dynamic Icons
+**Learning:** When a single button dynamically changes its visual icon and primary function based on state (e.g., a "Reload" button turning into a "Stop" button during loading), VoiceOver users miss out on this context if the `accessibilityLabel` remains static.
+**Action:** Always dynamically update the `accessibilityLabel` alongside visual changes to accurately describe the current actionable state to VoiceOver users.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -226,6 +226,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
+    self.closeButton.accessibilityLabel = @"Close";
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
     self.closeButton.hidden = !showsCloseButton;
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
@@ -6645,12 +6646,17 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     [_toolbarCard addSubview:controlsRow];
 
     _backButton = [self browserButtonWithTitle:@"<" action:@selector(goBack:)];
+    _backButton.accessibilityLabel = @"Back";
     _forwardButton = [self browserButtonWithTitle:@">" action:@selector(goForward:)];
+    _forwardButton.accessibilityLabel = @"Forward";
     _reloadButton = [self browserButtonWithTitle:@"R" action:@selector(reloadOrStop:)];
+    _reloadButton.accessibilityLabel = @"Reload";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _goButton = [self browserButtonWithTitle:@"Go" action:@selector(commitAddress:)];
     _addTabButton = [self browserButtonWithTitle:@"+" action:@selector(addTab:)];
+    _addTabButton.accessibilityLabel = @"Add Tab";
     _closeTabButton = [self browserButtonWithTitle:@"×" action:@selector(closeCurrentTab:)];
+    _closeTabButton.accessibilityLabel = @"Close Tab";
     UILongPressGestureRecognizer *homeLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleHomeButtonLongPress:)];
     homeLongPressRecognizer.minimumPressDuration = 0.35;
@@ -6798,6 +6804,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _closeTabButton.enabled = _tabWebViews.count > 1;
     _closeTabButton.alpha = _closeTabButton.enabled ? 1.0 : 0.42;
     [_reloadButton setTitle:(currentWebView.loading ? @"X" : @"R") forState:UIControlStateNormal];
+    _reloadButton.accessibilityLabel = currentWebView.loading ? @"Stop" : @"Reload";
     _progressView.hidden = !currentWebView.loading && currentWebView.estimatedProgress >= 0.999;
     _progressView.alpha = _progressView.hidden ? 0.0 : 1.0;
     if (!_addressField.isFirstResponder) {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,11 @@
+1. **Add accessibility label to the Close button:**
+   - In `app/WorkspaceViewController.m` where `self.closeButton` is created, add `self.closeButton.accessibilityLabel = @"Close";` since it uses the `×` icon which is not inherently descriptive.
+
+2. **Add accessibility labels to the Browser action buttons:**
+   - In `app/WorkspaceViewController.m`, inside the `browserButtonWithTitle:action:` or where buttons are configured, add descriptive `accessibilityLabel` for icon-only buttons (`_backButton`, `_forwardButton`, `_reloadButton`, `_addTabButton`, `_closeTabButton`).
+
+3. **Dynamically update `accessibilityLabel` for the Reload button:**
+   - In `refreshBrowserChrome`, where `_reloadButton`'s title is toggled between `X` and `R`, also toggle its `accessibilityLabel` between `@"Stop"` and `@"Reload"` to ensure the actionable state is communicated to VoiceOver.
+
+4. **Verify changes and complete pre-commit steps:**
+   - Explicitly delete temporary files, build/run tests to ensure the changes are valid, and complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
💡 What: Added descriptive `accessibilityLabel`s to all icon-only buttons (Close, Back, Forward, Reload, Add Tab, Close Tab). The Reload button's label also dynamically updates to "Stop" when a page is loading.
🎯 Why: Icon-only buttons (like `×`, `<`) are read literally by VoiceOver, confusing screen reader users. Adding labels ensures the interface is accessible and navigable for everyone.
♿ Accessibility: Ensures VoiceOver accurately announces the function of navigational controls.

---
*PR created automatically by Jules for task [598069517901781657](https://jules.google.com/task/598069517901781657) started by @emkey1*