### PR TITLE
🎨 Palette: Expose visual UI selection state to screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Accessibility Traits for UI Selection State
+**Learning:** In iOS UI development (e.g., `app/WorkspaceViewController.m`), dynamically changing the visual appearance of selection elements (like themes, tabs, or workspaces) using background colors or borders does not expose the selected state to VoiceOver users.
+**Action:** Always dynamically apply `UIAccessibilityTraitSelected` (`|=`) to active selection buttons and clear it (`&= ~`) for inactive ones concurrently with visual styling updates to ensure screen readers accurately communicate the active selection.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -5144,6 +5144,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     for (UIButton *button in _themeSelectionButtons) {
         NSString *identifier = button.accessibilityIdentifier;
         BOOL selected = [identifier isEqualToString:ISHWorkspaceCurrentThemeIdentifier()];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = selected
             ? [theme[@"accent"] colorWithAlphaComponent:0.34]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
@@ -6439,6 +6444,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         if (button == nil)
             continue;
         BOOL current = [descriptor[@"isCurrent"] boolValue];
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = current
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
@@ -6985,6 +6995,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     }
     for (UIButton *button in _tabButtons) {
         BOOL selected = button.tag == _selectedTabIndex;
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = selected
             ? [theme[@"accent"] colorWithAlphaComponent:0.18]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];


### PR DESCRIPTION
💡 What: Ensure visual selection states are exposed to screen readers by setting `UIAccessibilityTraitSelected`.
🎯 Why: In `WorkspaceViewController.m`, several UI elements (theme selector, scene switcher, browser tabs) indicated selection exclusively through background color changes. These dynamic style changes are invisible to screen readers, making it difficult for VoiceOver users to understand which option is currently active.
📸 Before/After: Visuals are unchanged.
♿ Accessibility: The `accessibilityTraits` property now accurately reflects the selection state, greatly improving navigation for users dependent on VoiceOver.

---
*PR created automatically by Jules for task [11369901355323492895](https://jules.google.com/task/11369901355323492895) started by @emkey1*