### PR TITLE
🎨 Palette: Add accessibility labels to textual icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,11 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Accessibility Labels for Textual Icon Buttons
+**Learning:** Icon-only buttons or buttons using non-standard textual symbols (e.g., '×' for close) are read literally by screen readers (e.g., "multiplication sign").
+**Action:** Always provide an explicit `accessibilityLabel` (e.g., @"Close") for buttons relying on textual symbols for icons to ensure VoiceOver announces their function correctly.
+
+## 2024-05-30 - Dynamic Accessibility Labels for State-Changing Buttons
+**Learning:** When a button dynamically changes its visual icon and function based on state (e.g., a "Reload" button turning into a "Stop" ("X") button while loading), its `accessibilityLabel` must also be dynamically updated to reflect the new state. Otherwise, VoiceOver will continue reading the original label, causing confusion about the button's current action.
+**Action:** Always dynamically update the `accessibilityLabel` concurrently with any dynamic changes to a button's visual title/icon when its primary action changes based on state (e.g., `_reloadButton.accessibilityLabel = loading ? @"Stop" : @"Reload"`).

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -226,6 +226,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     self.closeButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.closeButton setTitle:@"×" forState:UIControlStateNormal];
+    self.closeButton.accessibilityLabel = @"Close";
     self.closeButton.titleLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightSemibold];
     self.closeButton.hidden = !showsCloseButton;
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
@@ -6645,12 +6646,17 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     [_toolbarCard addSubview:controlsRow];
 
     _backButton = [self browserButtonWithTitle:@"<" action:@selector(goBack:)];
+    _backButton.accessibilityLabel = @"Back";
     _forwardButton = [self browserButtonWithTitle:@">" action:@selector(goForward:)];
+    _forwardButton.accessibilityLabel = @"Forward";
     _reloadButton = [self browserButtonWithTitle:@"R" action:@selector(reloadOrStop:)];
+    _reloadButton.accessibilityLabel = @"Reload";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _goButton = [self browserButtonWithTitle:@"Go" action:@selector(commitAddress:)];
     _addTabButton = [self browserButtonWithTitle:@"+" action:@selector(addTab:)];
+    _addTabButton.accessibilityLabel = @"New Tab";
     _closeTabButton = [self browserButtonWithTitle:@"×" action:@selector(closeCurrentTab:)];
+    _closeTabButton.accessibilityLabel = @"Close Tab";
     UILongPressGestureRecognizer *homeLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleHomeButtonLongPress:)];
     homeLongPressRecognizer.minimumPressDuration = 0.35;
@@ -6798,6 +6804,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _closeTabButton.enabled = _tabWebViews.count > 1;
     _closeTabButton.alpha = _closeTabButton.enabled ? 1.0 : 0.42;
     [_reloadButton setTitle:(currentWebView.loading ? @"X" : @"R") forState:UIControlStateNormal];
+    _reloadButton.accessibilityLabel = currentWebView.loading ? @"Stop" : @"Reload";
     _progressView.hidden = !currentWebView.loading && currentWebView.estimatedProgress >= 0.999;
     _progressView.alpha = _progressView.hidden ? 0.0 : 1.0;
     if (!_addressField.isFirstResponder) {


### PR DESCRIPTION
💡 **What**: Added `accessibilityLabel` properties to several buttons in the Workspace UI that rely on textual symbols for their visual icons (e.g., Close, Back, Forward, Reload, New Tab, Close Tab). Also made the Reload button's label dynamic so it correctly reads as "Stop" when the page is actively loading.
🎯 **Why**: When a button uses a textual character (like "×") instead of a standard image or system icon, VoiceOver will literally read the character out loud to the user (e.g., "multiplication sign"). This is highly confusing. Adding an explicit `accessibilityLabel` provides the semantic meaning ("Close") to screen readers while preserving the visual appearance. Dynamic updates are necessary when the primary action of the button changes (e.g., Reload to Stop) so the screen reader doesn't become out of sync with the visual state.
📸 **Before/After**: No visual changes.
♿ **Accessibility**: Significantly improves VoiceOver navigation in the workspace view by ensuring icon-only textual buttons announce their function instead of reading character literals.

---
*PR created automatically by Jules for task [11759089449190401093](https://jules.google.com/task/11759089449190401093) started by @emkey1*