### PR TITLE
🎨 Palette: Add dynamic accessibility labels to browser buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Dynamic Accessibility Labels for State-Changing Buttons
+**Learning:** When a single button dynamically changes its visual icon and primary function based on state (e.g., a "Reload" button turning into a "Stop" button during loading), its `accessibilityLabel` must be dynamically updated alongside the visual change to accurately describe the current actionable state to VoiceOver users.
+**Action:** Always dynamically set the `accessibilityLabel` property for state-changing buttons concurrently with visual property updates (e.g., `setTitle:`). Add explicit `accessibilityLabel` properties to all icon-only or abbreviated-text buttons.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6645,12 +6645,17 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     [_toolbarCard addSubview:controlsRow];
 
     _backButton = [self browserButtonWithTitle:@"<" action:@selector(goBack:)];
+    _backButton.accessibilityLabel = @"Back";
     _forwardButton = [self browserButtonWithTitle:@">" action:@selector(goForward:)];
+    _forwardButton.accessibilityLabel = @"Forward";
     _reloadButton = [self browserButtonWithTitle:@"R" action:@selector(reloadOrStop:)];
+    _reloadButton.accessibilityLabel = @"Reload page";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _goButton = [self browserButtonWithTitle:@"Go" action:@selector(commitAddress:)];
     _addTabButton = [self browserButtonWithTitle:@"+" action:@selector(addTab:)];
+    _addTabButton.accessibilityLabel = @"New tab";
     _closeTabButton = [self browserButtonWithTitle:@"×" action:@selector(closeCurrentTab:)];
+    _closeTabButton.accessibilityLabel = @"Close tab";
     UILongPressGestureRecognizer *homeLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleHomeButtonLongPress:)];
     homeLongPressRecognizer.minimumPressDuration = 0.35;
@@ -6798,6 +6803,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _closeTabButton.enabled = _tabWebViews.count > 1;
     _closeTabButton.alpha = _closeTabButton.enabled ? 1.0 : 0.42;
     [_reloadButton setTitle:(currentWebView.loading ? @"X" : @"R") forState:UIControlStateNormal];
+    _reloadButton.accessibilityLabel = currentWebView.loading ? @"Stop loading" : @"Reload page";
     _progressView.hidden = !currentWebView.loading && currentWebView.estimatedProgress >= 0.999;
     _progressView.alpha = _progressView.hidden ? 0.0 : 1.0;
     if (!_addressField.isFirstResponder) {


### PR DESCRIPTION
🎨 Palette: [UX improvement]

💡 What: Added explicitly defined `accessibilityLabel` properties to icon-only buttons in the Workspace Browser (Back, Forward, Reload, New Tab, Close Tab). Made the Reload button's label dynamically update between "Reload page" and "Stop loading" based on the `currentWebView.loading` state. Added a journal entry detailing the learning about dynamic states.
🎯 Why: VoiceOver users will no longer hear raw character representations (e.g. "times" for "×" or "less than" for "<"). Furthermore, when the page is loading, VoiceOver will correctly announce the button's action as "Stop loading" instead of "Reload page", ensuring an accurate representation of the actionable state.
📸 Before/After: Visuals are completely unaffected; changes are exclusively applied to `accessibilityLabel`.
♿ Accessibility: Ensures WCAG compliance for actionable control descriptions and state representation, providing a smooth screen-reader experience.

---
*PR created automatically by Jules for task [5657687088031594397](https://jules.google.com/task/5657687088031594397) started by @emkey1*