### PR TITLE
🎨 Palette: Expose active workspace scene state to screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-30 - Workspace Scene Button Accessibility
+**Learning:** When dynamically updating the visual appearance (e.g., border color or background) of dynamically generated control items like workspace scene buttons to indicate selection (`isCurrent`), screen readers will not announce the state if `accessibilityTraits` are not also updated.
+**Action:** When applying a selected visual style to a scene or tab button in `workspaceApplyTheme`, always ensure `UIAccessibilityTraitSelected` is explicitly added (`|=`) for the current item and removed (`&= ~`) for non-current ones.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6456,6 +6456,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
         button.layer.borderColor = (current ? theme[@"accentAlt"] : theme[@"stroke"]).CGColor;
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         UIImageView *previewView = _previewImageViewsByIdentifier[identifier];
         CGSize previewSize = previewView.bounds.size;
         if (previewSize.width < 24 || previewSize.height < 24)


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` to workspace scene buttons when they represent the current workspace.
🎯 Why: Workspace scene buttons visually indicate if they are the currently active workspace, but this state was completely invisible to VoiceOver users because the button's `accessibilityTraits` were not being updated.
♿ Accessibility: Ensures VoiceOver accurately announces "Selected" when navigating over the active workspace scene button, providing parity with the visual state.

---
*PR created automatically by Jules for task [4313397830622464748](https://jules.google.com/task/4313397830622464748) started by @emkey1*