### PR TITLE
🎨 Palette: Improve accessibility for selected state in workspace tabs and themes

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -5157,6 +5157,11 @@ NSString *ISHWorkspaceToolIdentifierForViewController(UIViewController *viewCont
     for (UIButton *button in _themeSelectionButtons) {
         NSString *identifier = button.accessibilityIdentifier;
         BOOL selected = [identifier isEqualToString:ISHWorkspaceCurrentThemeIdentifier()];
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = selected
             ? [theme[@"accent"] colorWithAlphaComponent:0.34]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];
@@ -6452,6 +6457,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         if (button == nil)
             continue;
         BOOL current = [descriptor[@"isCurrent"] boolValue];
+        if (current) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = current
             ? [theme[@"accent"] colorWithAlphaComponent:0.16]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.94];
@@ -6998,6 +7008,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     }
     for (UIButton *button in _tabButtons) {
         BOOL selected = button.tag == _selectedTabIndex;
+        if (selected) {
+            button.accessibilityTraits |= UIAccessibilityTraitSelected;
+        } else {
+            button.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        }
         button.backgroundColor = selected
             ? [theme[@"accent"] colorWithAlphaComponent:0.18]
             : [theme[@"cardAlt"] colorWithAlphaComponent:0.92];


### PR DESCRIPTION
**What:** This PR dynamically updates the `accessibilityTraits` for buttons serving as selectable tabs or theme options in `WorkspaceViewController.m`.

**Why:** When the visual styling (background color, borders, etc.) of a selection element changes to indicate it is selected, this state change is invisible to VoiceOver users unless explicitly communicated.

**Before/After:** No visual changes.

**Accessibility:** Added the `UIAccessibilityTraitSelected` trait to active selection buttons (themes, browser tabs, workspaces) and cleared it from inactive buttons when the theme is applied. This accurately describes the actionable state to VoiceOver users.

---
*PR created automatically by Jules for task [4592899473277201525](https://jules.google.com/task/4592899473277201525) started by @emkey1*