### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential buffer overflows by replacing sprintf with snprintf

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -40,3 +40,7 @@
 **Vulnerability:** A fixed-size stack buffer (`char envp[100]`) in `main.c` and `tools/ptraceomatic.c` was vulnerable to a buffer overflow when constructing the `TERM` environment variable. A user could trigger a Denial of Service (DoS) or stack corruption by supplying a `TERM` string exceeding the 100-character stack limit.
 **Learning:** Hardcoding stack buffer limits for dynamically sized user inputs (like environment variables) creates critical security risks and should be dynamically allocated instead.
 **Prevention:** Always use safe construction methods (e.g. `snprintf` with `malloc`) when passing dynamically-sized string inputs into kernel or environment initialization bounds, verifying explicitly free routines.
+## 2026-06-01 - Replace unsafe sprintf calls with snprintf across codebase
+**Vulnerability:** Unbounded string formatting (`sprintf`) writing to fixed-size char arrays in various files (e.g., `fs/sock.c`, `fs/proc/pid.c`, `tools/vdso-transplant.c`, `emu/regid.h`).
+**Learning:** Legacy codebase components often lack explicit bounds checking for formatted strings, relying on assumptions about maximum path or PID lengths. This creates potential buffer overflow vulnerabilities.
+**Prevention:** Always use `snprintf` with explicit buffer size limits (e.g., `sizeof(buffer)`, `MAX_PATH`, `MAX_NAME + 1`) instead of the unsafe `sprintf` to ensure robust bounds checking across the codebase.

--- a/emu/regid.h
+++ b/emu/regid.h
@@ -59,8 +59,8 @@ struct regptr {
     reg_id_t reg128_id;
 };
 static __attribute__((unused)) const char *regptr_name(struct regptr regptr) {
-    static char buf[15];
-    sprintf(buf, "%s/%s/%s",
+    static char buf[64];
+    snprintf(buf, sizeof(buf), "%s/%s/%s",
             regid8_name(regptr.reg8_id),
             regid16_name(regptr.reg16_id),
             regid32_name(regptr.reg32_id));

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -19,7 +19,7 @@ extern dword_t extra_lock_pid;
 extern const char extra_lock_comm;
 
 static void proc_pid_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->pid);
+    snprintf(buf, MAX_NAME + 1, "%d", entry->pid);
 }
 
 static char proc_task_state_char_from_snapshot(pid_t_ pid, bool zombie, bool io_block, bool stopped) {
@@ -703,7 +703,7 @@ static bool proc_pid_fd_readdir(struct proc_entry *entry, unsigned long *index, 
 }
 
 static void proc_pid_fd_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->fd);
+    snprintf(buf, MAX_NAME + 1, "%d", entry->fd);
 }
 
 static bool proc_pid_fdinfo_readdir(struct proc_entry *entry, unsigned long *index, struct proc_entry *next_entry) {
@@ -805,7 +805,7 @@ static int proc_pid_exe_readlink(struct proc_entry *entry, char *buf) {
 }
 
 static void proc_pid_task_getname(struct proc_entry *entry, char *buf) {
-    sprintf(buf, "%d", entry->pid);
+    snprintf(buf, MAX_NAME + 1, "%d", entry->pid);
 }
 
 static struct proc_dir_entry proc_pid_task;

--- a/fs/proc/root.c
+++ b/fs/proc/root.c
@@ -352,7 +352,7 @@ static int proc_show_loadavg(struct proc_entry *UNUSED(entry), struct proc_data 
 }
 
 static int proc_readlink_self(struct proc_entry *UNUSED(entry), char *buf) {
-    sprintf(buf, "%d/", current->pid);
+    snprintf(buf, MAX_PATH, "%d/", current->pid);
     return 0;
 }
 
@@ -868,7 +868,7 @@ static int sysfs_getpath(struct fd *fd, char *buf) {
             strcpy(buf, "/devices/system/cpu/offline");
             break;
         case sysfs_cpu_dir:
-            sprintf(buf, "/devices/system/cpu/cpu%d", node.cpu);
+            snprintf(buf, MAX_PATH, "/devices/system/cpu/cpu%d", node.cpu);
             break;
     }
     return 0;

--- a/fs/pty.c
+++ b/fs/pty.c
@@ -203,7 +203,7 @@ static int devpts_getpath(struct fd *fd, char *buf) {
     if (fd->devpts.num == -1)
         memcpy(buf, "", 1);
     else
-        sprintf(buf, "/%d", fd->devpts.num);
+        snprintf(buf, MAX_PATH, "/%d", fd->devpts.num);
     return 0;
 }
 
@@ -295,7 +295,7 @@ static int devpts_readdir(struct fd *fd, struct dir_entry *entry) {
     if (pty_num >= MAX_PTYS)
         return 0;
     fd->offset = pty_num + 1;
-    sprintf(entry->name, "%d", pty_num);
+    snprintf(entry->name, sizeof(entry->name), "%d", pty_num);
     entry->inode = pty_num + 3;
     entry->type = DT_CHR;
    // if (minor == DEV_PTMX_MINOR) 

--- a/fs/sock.c
+++ b/fs/sock.c
@@ -2086,7 +2086,9 @@ static int sockaddr_read_bind(guest_addr_t sockaddr_addr, void *sockaddr, uint_t
             }
 
             struct sockaddr_un *real_addr_un = sockaddr;
-            size_t path_len = sprintf(real_addr_un->sun_path, "%s.%u", sock_tmp_prefix, socket_id);
+            size_t path_len = snprintf(real_addr_un->sun_path, sizeof(real_addr_un->sun_path), "%s.%u", sock_tmp_prefix, socket_id);
+            if (path_len >= sizeof(real_addr_un->sun_path))
+                path_len = sizeof(real_addr_un->sun_path) - 1;
 #ifdef __APPLE__
             real_addr_un->sun_len = offsetof(struct sockaddr_un, sun_path) + path_len;
 #endif

--- a/tools/ptutil.c
+++ b/tools/ptutil.c
@@ -55,7 +55,7 @@ int start_tracee(int at, const char *path, char *const argv[], char *const envp[
 
 int open_mem(int pid) {
     char filename[1024];
-    sprintf(filename, "/proc/%d/mem", pid);
+    snprintf(filename, sizeof(filename), "/proc/%d/mem", pid);
     return trycall(open(filename, O_RDWR), "open mem");
 }
 

--- a/tools/vdso-transplant.c
+++ b/tools/vdso-transplant.c
@@ -40,8 +40,8 @@ static void aux_write(int pid, int type, dword_t value) {
 
 void transplant_vdso(int pid, const void *new_vdso, size_t new_vdso_size) {
     // get the vdso address and size from /proc/pid/maps
-    char maps_file[32];
-    sprintf(maps_file, "/proc/%d/maps", pid);
+    char maps_file[64];
+    snprintf(maps_file, sizeof(maps_file), "/proc/%d/maps", pid);
     FILE *maps = fopen(maps_file, "r");
 
     char line[256];


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix potential buffer overflows by replacing sprintf with snprintf

Severity: HIGH
Vulnerability: Unbounded string formatting (`sprintf`) writing to fixed-size char arrays in various components (e.g., `fs/sock.c`, `fs/proc/pid.c`, `tools/vdso-transplant.c`, `emu/regid.h`) could lead to potential buffer overflows if arguments exceed expected lengths.
Impact: Potential stack/heap corruption and denial of service or execution control by malicious paths or PIDs.
Fix: Replaced `sprintf` calls with safer `snprintf` calls explicitly bound to the destination buffer sizes (`sizeof(buffer)`, `MAX_PATH`, `MAX_NAME + 1`).
Verification: Built codebase successfully via `meson` and `ninja`. Code inspected to ensure bounded format strings.

---
*PR created automatically by Jules for task [18001141862314674244](https://jules.google.com/task/18001141862314674244) started by @emkey1*