### PR TITLE
🎨 Palette: Improve accessibility labels for workspace buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-05-29 - Icon-Only Button Accessibility
+**Learning:** Icon-only buttons using non-standard textual symbols (like the '×' close button in WorkspaceViewController) are announced literally by VoiceOver (e.g., "multiply" or "cross"), which is unhelpful for users.
+**Action:** Always provide an explicit, descriptive `accessibilityLabel` (e.g., @"Close Window") for buttons lacking standard text titles or system icons.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -231,6 +231,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
     self.closeButton.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.82];
     self.closeButton.layer.cornerRadius = ISHWorkspaceWindowButtonSize * 0.5;
+    self.closeButton.accessibilityLabel = @"Close Window";
     [self.closeButton addTarget:self action:@selector(closePressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.titleBarView addSubview:self.closeButton];
 
@@ -389,6 +390,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.utilityHandler = handler;
     BOOL visible = title.length > 0 && handler != nil;
     [self.utilityButton setTitle:title forState:UIControlStateNormal];
+    self.utilityButton.accessibilityLabel = title;
     self.utilityButton.hidden = !visible;
     self.utilityButton.alpha = visible ? 1.0 : 0.0;
 }


### PR DESCRIPTION
💡 What: Added explicit `accessibilityLabel` properties to `closeButton` (@"Close Window") and `utilityButton` (dynamic title) in `WorkspaceViewController`.
🎯 Why: VoiceOver was reading the literal mathematical character for the "×" close button ("multiply" or "cross") and providing no useful information. The utility button also needed its title explicitly set for accessibility.
📸 Before/After: Visuals unchanged, VoiceOver now reads "Close Window".
♿ Accessibility: Improves experience for VoiceOver users when interacting with workspace windows by providing clear, functional descriptions instead of literal character readings.

---
*PR created automatically by Jules for task [12650513827202630321](https://jules.google.com/task/12650513827202630321) started by @emkey1*