### PR TITLE
⚡ Bolt: [performance improvement] Eliminate redundant strlen in tmpfs_getpath

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2026-03-25 - Hoist string length calculations in VFS inner functions
 **Learning:** In `fs/dir.c`, `sys_getdents_common` repeatedly called `strlen` inside a directory traversal loop, both directly and indirectly via callback functions (`fill_dirent`). This caused redundant O(N) traversals per entry, scaling poorly for large directories.
 **Action:** When a string's length is already known or can be hoisted outside an inner callback, pass the length as a parameter (e.g., `namelen` in `fill_dirent`) rather than recalculating it internally.
+## 2026-03-26 - Eliminate redundant strlen in backwards string construction
+**Learning:** In VFS path construction functions (like `tmpfs_getpath`), when a path string is built backwards from the end of a fixed-size buffer, calling `strlen()` on the resulting pointer to find the total length incurs a redundant O(N) traversal.
+**Action:** When building strings backwards, calculate the final length using pointer arithmetic (e.g., `(size_t)((buf + MAX_PATH) - p)`) instead of `strlen() + 1` to eliminate the unnecessary O(N) recalculation.

--- a/fs/tmp.c
+++ b/fs/tmp.c
@@ -591,7 +591,7 @@ static int tmpfs_getpath(struct fd *fd, char *buf) {
         memcpy(&p[1], dirent->name, name_len);
         dirent = dirent->parent;
     }
-    memmove(buf, p, strlen(p) + 1);
+    memmove(buf, p, (size_t)((buf + MAX_PATH) - p));
     return 0;
 }
 


### PR DESCRIPTION
💡 **What:** Replaced `strlen(p) + 1` with `(size_t)((buf + MAX_PATH) - p)` in `tmpfs_getpath` inside `fs/tmp.c`.
🎯 **Why:** To eliminate an unnecessary O(N) string traversal when the final length is mathematically implicit due to backwards string construction from a fixed-size buffer boundary.
📊 **Impact:** Reduces computational overhead (O(N) to O(1)) in a heavily utilized VFS path resolution path, yielding a small performance boost for file operations on tmpfs.
🔬 **Measurement:** Verify with `meson setup build && ninja -C build` and `./tests/e2e/e2e.bash` (accepting known environment-related compilation failures for apple-specific components).

Appended the corresponding learning to the `.jules/bolt.md` journal.

---
*PR created automatically by Jules for task [1195642679855180166](https://jules.google.com/task/1195642679855180166) started by @emkey1*