### PR TITLE
🎨 Palette: [Accessibility] Add VoiceOver labels to Workspace controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-28 - Exposing Visual Badges to Screen Readers
 **Learning:** Visual indicators, such as a red badge signaling an available update, are invisible to screen readers unless their state is programmatically exposed.
 **Action:** When adding or updating visual badges on UI elements, always set a corresponding descriptive `accessibilityValue` (e.g., `@"Update available"`) on the element or its parent container when the badge is visible, and clear it (`nil`) when the badge is hidden, avoiding cluttering the main `accessibilityLabel`.
+
+## 2024-06-03 - Dynamic Accessibility Labels for State-Changing Buttons
+**Learning:** In iOS UI development, when a single button dynamically changes its visual icon and primary function based on state (e.g., setting a new title or action dynamically), its `accessibilityLabel` must be dynamically updated alongside the visual change to accurately describe the current actionable state to VoiceOver users.
+**Action:** When updating a button's visual representation (e.g., via `setTitle:`), ensure you also dynamically update `accessibilityLabel` to match the new state or function.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -231,6 +231,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.closeButton.alpha = showsCloseButton ? 1.0 : 0.0;
     self.closeButton.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.82];
     self.closeButton.layer.cornerRadius = ISHWorkspaceWindowButtonSize * 0.5;
+    self.closeButton.accessibilityLabel = @"Close Window";
     [self.closeButton addTarget:self action:@selector(closePressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.titleBarView addSubview:self.closeButton];
 
@@ -389,6 +390,7 @@ static CGRect ISHWorkspaceRectWithRoundedOriginPreservingSize(CGRect frame) {
     self.utilityHandler = handler;
     BOOL visible = title.length > 0 && handler != nil;
     [self.utilityButton setTitle:title forState:UIControlStateNormal];
+    self.utilityButton.accessibilityLabel = title;
     self.utilityButton.hidden = !visible;
     self.utilityButton.alpha = visible ? 1.0 : 0.0;
 }


### PR DESCRIPTION
💡 **What**: Added descriptive `accessibilityLabel` properties to the `closeButton` and dynamically to the `utilityButton` within `WorkspaceViewController`.

🎯 **Why**: Previously, VoiceOver would read the literal character "×" for the close button, which is confusing for users relying on screen readers. Similarly, the utility button lacked dynamic accessibility labels when its state and title changed. This change ensures VoiceOver users receive clear, actionable descriptions for window controls.

📸 **Before/After**: N/A (Non-visual change, affects VoiceOver only).

♿ **Accessibility**: 
- The icon-only close button now announces as "Close Window" to screen readers.
- The utility button now dynamically sets its `accessibilityLabel` to match its current title state when updated via `setUtilityButtonTitle:handler:`.

---
*PR created automatically by Jules for task [14154645463396104612](https://jules.google.com/task/14154645463396104612) started by @emkey1*