### PR TITLE
🎨 Palette: [Add accessibility labels to symbol-only browser buttons]

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -6670,12 +6670,17 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     [_toolbarCard addSubview:controlsRow];
 
     _backButton = [self browserButtonWithTitle:@"<" action:@selector(goBack:)];
+    _backButton.accessibilityLabel = @"Back";
     _forwardButton = [self browserButtonWithTitle:@">" action:@selector(goForward:)];
+    _forwardButton.accessibilityLabel = @"Forward";
     _reloadButton = [self browserButtonWithTitle:@"R" action:@selector(reloadOrStop:)];
+    _reloadButton.accessibilityLabel = @"Reload";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _goButton = [self browserButtonWithTitle:@"Go" action:@selector(commitAddress:)];
     _addTabButton = [self browserButtonWithTitle:@"+" action:@selector(addTab:)];
+    _addTabButton.accessibilityLabel = @"Add Tab";
     _closeTabButton = [self browserButtonWithTitle:@"×" action:@selector(closeCurrentTab:)];
+    _closeTabButton.accessibilityLabel = @"Close Tab";
     UILongPressGestureRecognizer *homeLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleHomeButtonLongPress:)];
     homeLongPressRecognizer.minimumPressDuration = 0.35;
@@ -6823,6 +6828,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _closeTabButton.enabled = _tabWebViews.count > 1;
     _closeTabButton.alpha = _closeTabButton.enabled ? 1.0 : 0.42;
     [_reloadButton setTitle:(currentWebView.loading ? @"X" : @"R") forState:UIControlStateNormal];
+    _reloadButton.accessibilityLabel = currentWebView.loading ? @"Stop" : @"Reload";
     _progressView.hidden = !currentWebView.loading && currentWebView.estimatedProgress >= 0.999;
     _progressView.alpha = _progressView.hidden ? 0.0 : 1.0;
     if (!_addressField.isFirstResponder) {


### PR DESCRIPTION
💡 **What:** Added `accessibilityLabel` to symbol-only buttons in the browser view (`_backButton`, `_forwardButton`, `_reloadButton`, `_addTabButton`, `_closeTabButton`) and dynamically update the `_reloadButton`'s accessibility label to "Stop" while a page is loading.

🎯 **Why:** Icon-only buttons or buttons using obscure symbols (like `×` for close) are confusing or read literally by VoiceOver. This change ensures screen readers accurately describe the function of these essential navigation controls to users.

♿ **Accessibility:**
- Added standard descriptive string labels (e.g., "Back", "Forward", "Add Tab", "Close Tab") to buttons initialized without clear text.
- Ensured the dynamic visual state change of the reload/stop button ("R" to "X") is mirrored programmatically with dynamic accessibility label updates ("Reload" to "Stop").

---
*PR created automatically by Jules for task [888367251969877766](https://jules.google.com/task/888367251969877766) started by @emkey1*