### PR TITLE
⚡ Bolt: Hoist `pwd` string length in `sys_getcwd_common`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2026-03-26 - Eliminate redundant strlen in backwards string construction
 **Learning:** In VFS path construction functions (like `tmpfs_getpath`), when a path string is built backwards from the end of a fixed-size buffer, calling `strlen()` on the resulting pointer to find the total length incurs a redundant O(N) traversal.
 **Action:** When building strings backwards, calculate the final length using pointer arithmetic (e.g., `(size_t)((buf + MAX_PATH) - p)`) instead of `strlen() + 1` to eliminate the unnecessary O(N) recalculation.
+## 2026-03-27 - Hoist string length calculations in sys_getcwd_common
+**Learning:** In `kernel/fs.c`, `sys_getcwd_common` repeatedly called `strlen(pwd)` to determine the length of the current working directory string. This caused unnecessary O(N) traversals per operation, scaling poorly for long paths.
+**Action:** When a string's length needs to be used multiple times in an inner function, compute the length once and cache it in a variable (`pwd_len`) rather than recalculating it internally.

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -1226,9 +1226,10 @@ static dword_t sys_getcwd_common(guest_addr_t buf_addr, dword_t size) {
     if (err < 0)
         return err;
 
-    if (strlen(pwd) + 1 > size)
+    size_t pwd_len = strlen(pwd);
+    if (pwd_len + 1 > size)
         return _ERANGE;
-    size = strlen(pwd) + 1;
+    size = pwd_len + 1;
     STRACE(" \"%.*s\"", size, pwd);
     dword_t res = size;
 


### PR DESCRIPTION
What: Compute `strlen(pwd)` once and cache the result in a `pwd_len` variable.
Why: Previously, `sys_getcwd_common` in `kernel/fs.c` called `strlen(pwd)` twice to verify if the path fits in the buffer, which led to redundant O(N) traversals per operation.
Impact: Reduces redundant work for path building operations, improving performance.
Measurement: Verified via inspecting VFS function implementations to confirm the length is reused instead of recalculated. Tests ran correctly with expected partial environmental apple-specific compilation failures in the sandbox.

---
*PR created automatically by Jules for task [18305043001012526917](https://jules.google.com/task/18305043001012526917) started by @emkey1*