### PR TITLE
🎨 Palette: Update Send button accessibility label for loading state

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -1125,6 +1125,7 @@ static BOOL ISHLLMDirectHTTPPostStreaming(NSURL *url,
     _sendButton.enabled = !sending;
     _promptField.enabled = !sending;
     [_sendButton setTitle:(sending ? @"..." : @"Send") forState:UIControlStateNormal];
+    _sendButton.accessibilityLabel = sending ? @"Sending" : @"Send";
 }
 
 - (void)handleLLMResponseData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error {


### PR DESCRIPTION
💡 What: Added dynamic updates to the `accessibilityLabel` of the LLM chat's `_sendButton` when its state changes.
🎯 Why: Previously, when sending a request, the button's visual title changed to `"..."`. Screen readers would announce this unhelpfully (e.g., "dot dot dot button"). This change ensures the state is correctly announced as "Sending".
📸 Before/After: Visuals remain the same, but the screen reader announcement changes from "dot dot dot button" to "Sending button".
♿ Accessibility: Ensures VoiceOver accurately announces the state of the send button during asynchronous operations.

---
*PR created automatically by Jules for task [16952776831289415347](https://jules.google.com/task/16952776831289415347) started by @emkey1*