### PR TITLE
⚡ Bolt: Cache strlen result to avoid O(N) recalculations in proc_readlink

### DIFF
--- a/fs/proc.c
+++ b/fs/proc.c
@@ -249,8 +249,10 @@ static ssize_t proc_readlink(struct mount *UNUSED(mount), const char *path, char
     proc_entry_cleanup(&entry);
     if (err < 0)
         return err;
-    if (bufsize > strlen(target))
-        bufsize = strlen(target);
+
+    size_t target_len = strlen(target);
+    if (bufsize > target_len)
+        bufsize = target_len;
     memcpy(buf, target, bufsize);
     return bufsize;
 }


### PR DESCRIPTION
💡 What: Calculate `strlen(target)` once and cache it in `target_len` instead of evaluating it twice in `fs/proc.c` `proc_readlink()`.
🎯 Why: `strlen` operates with $O(N)$ time complexity. Evaluating it twice sequentially for the same string (`target`) is redundant and inefficient, especially in a commonly accessed kernel VFS function.
📊 Impact: Avoids a second $O(N)$ string traversal per `readlink` operation on the proc filesystem.
🔬 Measurement: Verified using standard test suites via `./tests/e2e/e2e.bash`. No regressions or new functional changes were introduced.

---
*PR created automatically by Jules for task [7764071697280555964](https://jules.google.com/task/7764071697280555964) started by @emkey1*