### PR TITLE
⚡ Bolt: Replace strcat with memcpy for dynamic string concatenations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2026-03-27 - Hoist string length calculations in sys_getcwd_common
 **Learning:** In `kernel/fs.c`, `sys_getcwd_common` repeatedly called `strlen(pwd)` to determine the length of the current working directory string. This caused unnecessary O(N) traversals per operation, scaling poorly for long paths.
 **Action:** When a string's length needs to be used multiple times in an inner function, compute the length once and cache it in a variable (`pwd_len`) rather than recalculating it internally.
+## 2026-06-16 - Prevent O(N) Recalculations with strcat
+**Learning:** Using `strcat` repeatedly for dynamic string concatenation (e.g., building `boot_command_line` or accumulating deduped cgroup controllers) causes O(N^2) complexity due to redundant string length recalculations on each append.
+**Action:** Replace `strcat` with direct memory manipulation using `memcpy` and track the accumulated string length explicitly in a variable (`len`). This reduces concatenation complexity to O(1) per append, significantly improving performance for repeated operations.

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -565,6 +565,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -584,8 +585,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");

--- a/linux/main.c
+++ b/linux/main.c
@@ -8,10 +8,15 @@ extern void run_kernel(void);
 int main(int argc, const char *argv[])
 {
 	int i;
+	size_t len = 0;
 	for (i = 1; i < argc; i++) {
-		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+		if (i > 1) {
+			boot_command_line[len++] = ' ';
+			boot_command_line[len] = '\0';
+		}
+		size_t arg_len = strlen(argv[i]);
+		memcpy(boot_command_line + len, argv[i], arg_len + 1);
+		len += arg_len;
 	}
 	run_kernel();
 	for (;;) host_pause();


### PR DESCRIPTION
💡 **What**: Replaced `strcat` calls with length tracking and `memcpy`/array assignment in `linux/main.c` (`boot_command_line` appending) and `fs/proc/pid.c` (`seen` buffer appending in `proc_pid_cgroup_show`).

🎯 **Why**: Using `strcat` in a loop causes O(N^2) complexity because it must traverse the entire destination string to find the null terminator for each append. Tracking the length explicitly and using `memcpy` reduces this to O(1) per append operation.

📊 **Impact**: Prevents redundant O(N) traversals per component appended during kernel boot and cgroup procfs reads, making string accumulation scale linearly instead of quadratically.

🔬 **Measurement**: Verified by running `tests/e2e/e2e.bash` to ensure `boot_command_line` parsing and procfs functionality remain intact without regressions.

---
*PR created automatically by Jules for task [16227916680749575259](https://jules.google.com/task/16227916680749575259) started by @emkey1*