### PR TITLE
⚡ Bolt: Optimize strcat in proc_pid_cgroup_show

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2026-03-27 - Hoist string length calculations in sys_getcwd_common
 **Learning:** In `kernel/fs.c`, `sys_getcwd_common` repeatedly called `strlen(pwd)` to determine the length of the current working directory string. This caused unnecessary O(N) traversals per operation, scaling poorly for long paths.
 **Action:** When a string's length needs to be used multiple times in an inner function, compute the length once and cache it in a variable (`pwd_len`) rather than recalculating it internally.
+## 2026-03-28 - Avoid strcat in proc_pid_cgroup_show
+**Learning:** In `fs/proc/pid.c`, the `proc_pid_cgroup_show` function iterates over cgroup mounts to generate process cgroup information, keeping track of seen controllers in a string `seen` using `strcat(seen, key)`. This requires an O(N) traversal of `seen` for every string concatenation, degrading performance as the number of mounts increases.
+**Action:** Replace `strcat` with explicit length tracking and `memcpy`. By maintaining a `seen_len` variable, the current end of the string is known in O(1) time, avoiding the O(N) cost of finding the null terminator.

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -565,6 +565,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -584,8 +585,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");


### PR DESCRIPTION
**💡 What**:
Replaced the `strcat(seen, key)` inside the cgroup iteration loop in `proc_pid_cgroup_show` (`fs/proc/pid.c`) with a length-tracked `memcpy`. We maintain the current length of the `seen` string using the `seen_len` variable.

**🎯 Why**:
`strcat` repeatedly traverses the destination string from the beginning to find the null terminator before appending. When looping through a list of mounted controllers to deduplicate them, this repeatedly recalculates the length of the string built so far, leading to O(N^2) time complexity for the string construction overall. Using a tracked length and `memcpy` brings the string append operation down to O(1).

**📊 Impact**:
Reduces CPU cycles and avoids quadratic scaling overhead inside a `list_for_each_entry` loop in the kernel when evaluating `/proc/<pid>/cgroup` for processes. Since the cgroups logic deduplicates hierarchy strings, it makes the loop strictly linear instead of quadratic. 

**🔬 Measurement**:
While I didn't successfully compile the full kernel unit test suite inside the sandboxed environment due to unmet dependencies (e.g., Apple's `xcode-meson.sh` and specific `gadget_amd64` linking requirements), I verified the logic in an isolated C test program to ensure exactly the same deduplication output and null-termination properties as the original `strcat` implementation.

---
*PR created automatically by Jules for task [1158340141885749086](https://jules.google.com/task/1158340141885749086) started by @emkey1*