### PR TITLE
🎨 Palette: [UX improvement] Add accessibility labels to Workspace browser toolbar elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-06-03 - Dynamic Accessibility Labels for State-Changing Buttons
 **Learning:** In iOS UI development, when a single button dynamically changes its visual icon and primary function based on state (e.g., setting a new title or action dynamically), its `accessibilityLabel` must be dynamically updated alongside the visual change to accurately describe the current actionable state to VoiceOver users.
 **Action:** When updating a button's visual representation (e.g., via `setTitle:`), ensure you also dynamically update `accessibilityLabel` to match the new state or function.
+
+## 2024-06-04 - Explicit Labels for Implicitly Grouped UI Controls
+**Learning:** In iOS UI development, interactive input elements like `UITextField` that lack adjacent visible textual labels (such as a browser address bar) must have an explicitly set `accessibilityLabel` to ensure VoiceOver users can clearly identify their purpose, even if placeholder text exists. Additionally, ensuring all controls in a toolbar (like 'Home' and 'Go' buttons) have `accessibilityLabel`s ensures a consistent experience for screen reader users.
+**Action:** When adding or modifying unlabeled input fields or icon/text buttons in toolbars, always set a clear `accessibilityLabel` property.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -7908,7 +7908,9 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _reloadButton = [self browserButtonWithTitle:@"R" action:@selector(reloadOrStop:)];
     _reloadButton.accessibilityLabel = @"Reload";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
+    _homeButton.accessibilityLabel = @"Home";
     _goButton = [self browserButtonWithTitle:@"Go" action:@selector(commitAddress:)];
+    _goButton.accessibilityLabel = @"Go";
     _addTabButton = [self browserButtonWithTitle:@"+" action:@selector(addTab:)];
     _addTabButton.accessibilityLabel = @"Add Tab";
     _closeTabButton = [self browserButtonWithTitle:@"×" action:@selector(closeCurrentTab:)];
@@ -7932,6 +7934,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
 
     _addressField = [UITextField new];
     _addressField.translatesAutoresizingMaskIntoConstraints = NO;
+    _addressField.accessibilityLabel = @"Address bar";
     _addressField.delegate = self;
     _addressField.clearButtonMode = UITextFieldViewModeWhileEditing;
     _addressField.returnKeyType = UIReturnKeyGo;


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add accessibility labels to Workspace browser toolbar elements

💡 What: Added explicit `accessibilityLabel` properties to the `_homeButton`, `_goButton`, and `_addressField` in the Workspace Browser view.
🎯 Why: VoiceOver users could not easily identify the purpose of the address text field or certain buttons in the browser toolbar, as they lacked explicit labels.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: The "Address bar", "Home", and "Go" controls are now explicitly announced by VoiceOver, matching the rest of the browser controls.

---
*PR created automatically by Jules for task [2718217844746125466](https://jules.google.com/task/2718217844746125466) started by @emkey1*