### PR TITLE
🎨 Palette: [UX improvement] Add accessibility label to address field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-06-03 - Dynamic Accessibility Labels for State-Changing Buttons
 **Learning:** In iOS UI development, when a single button dynamically changes its visual icon and primary function based on state (e.g., setting a new title or action dynamically), its `accessibilityLabel` must be dynamically updated alongside the visual change to accurately describe the current actionable state to VoiceOver users.
 **Action:** When updating a button's visual representation (e.g., via `setTitle:`), ensure you also dynamically update `accessibilityLabel` to match the new state or function.
+
+## 2024-06-22 - Missing Accessibility Labels on Text Fields
+**Learning:** Interactive input elements like `UITextField` that lack adjacent visible textual labels (such as a browser address bar) must have an explicitly set `accessibilityLabel` to ensure VoiceOver users can clearly identify their purpose.
+**Action:** When adding or maintaining a `UITextField` without a visible text label, always add a descriptive `accessibilityLabel` (e.g., `@"Address Bar"`).

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8158,6 +8158,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField = [UITextField new];
     _addressField.translatesAutoresizingMaskIntoConstraints = NO;
     _addressField.delegate = self;
+    _addressField.accessibilityLabel = @"Address Bar";
     _addressField.clearButtonMode = UITextFieldViewModeWhileEditing;
     _addressField.returnKeyType = UIReturnKeyGo;
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
What: Added an `accessibilityLabel` of `"Address Bar"` to the main `_addressField` in `app/WorkspaceViewController.m`.
Why: The text field serves as an interactive input element for the browser address but lacked a visible text label. Without an explicit `accessibilityLabel`, VoiceOver users couldn't identify the purpose of this critical UI element.
Accessibility: Improved accessibility for screen readers by adding a descriptive label to an unlabeled text input field. This ensures VoiceOver correctly announces the field's purpose.

---
*PR created automatically by Jules for task [7186496355667964558](https://jules.google.com/task/7186496355667964558) started by @emkey1*