### PR TITLE
⚡ Bolt: Optimize dynamic string concatenation in loops

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2); // includes null terminator
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");

--- a/linux/main.c
+++ b/linux/main.c
@@ -8,10 +8,20 @@ extern void run_kernel(void);
 int main(int argc, const char *argv[])
 {
 	int i;
+	size_t len = 0;
+	size_t limit = sizeof(boot_command_line);
 	for (i = 1; i < argc; i++) {
-		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+		if (i > 1) {
+			if (len + 1 < limit) {
+				boot_command_line[len++] = ' ';
+				boot_command_line[len] = '\0';
+			}
+		}
+		size_t arg_len = strlen(argv[i]);
+		if (len + arg_len < limit) {
+			memcpy(boot_command_line + len, argv[i], arg_len + 1);
+			len += arg_len;
+		}
 	}
 	run_kernel();
 	for (;;) host_pause();


### PR DESCRIPTION
💡 **What**: Replaced dynamic `strcat` usage with a length-tracking variable (`size_t len`) and `memcpy` inside loops in `linux/main.c` and `fs/proc/pid.c`. Added bounds checking against `sizeof(boot_command_line)` in `linux/main.c`.

🎯 **Why**: When dynamically building strings iteratively in loops (like processing command line arguments or deduplicating entries in `/proc`), using `strcat` results in O(N^2) complexity because the string must be traversed from the beginning on every append to find the null terminator. 

📊 **Impact**: Reduces string concatenation complexity from O(N^2) to O(N). Appending becomes an O(1) operation by writing directly to `buffer + len` and explicitly incrementing the `len` variable. The change in `main.c` also improves security by ensuring the `boot_command_line` buffer doesn't overflow if excessively large arguments are provided.

🔬 **Measurement**: Verified the compilation of the application and passing test suite using the sandbox environment instructions. Run the e2e test suite (which interacts with procfs) to verify correctness.

---
*PR created automatically by Jules for task [13877495652343904136](https://jules.google.com/task/13877495652343904136) started by @emkey1*