### PR TITLE
🎨 Palette: Improve accessibility of text fields

### DIFF
--- a/app/ThemeViewController.m
+++ b/app/ThemeViewController.m
@@ -68,6 +68,7 @@ struct PaletteTextFields {
     self.navigationItem.title = self.theme.name;
     
     _nameTextField = [self detailTextFieldWithText:_theme.name monospaced: NO];
+    _nameTextField.accessibilityLabel = @"Theme Name";
     _singlePaletteSwitch = [UISwitch new];
     _singlePaletteSwitch.on = self.theme.lightPalette == self.theme.darkPalette;
     [_singlePaletteSwitch addTarget:self action:@selector(singlePaletteChanged:) forControlEvents:UIControlEventValueChanged];
@@ -75,11 +76,15 @@ struct PaletteTextFields {
     for (int i = 0; i < sizeof(_paletteTextFields) / sizeof(*_paletteTextFields); ++i) {
         Palette *palette = i ? self.theme.darkPalette : self.theme.lightPalette;
         _paletteTextFields[i].foregroundTextField = [self detailTextFieldWithText:palette.foregroundColor monospaced:YES];
+        _paletteTextFields[i].foregroundTextField.accessibilityLabel = @"Foreground Color";
         _paletteTextFields[i].backgroundTextField = [self detailTextFieldWithText:palette.backgroundColor monospaced:YES];
+        _paletteTextFields[i].backgroundTextField.accessibilityLabel = @"Background Color";
         _paletteTextFields[i].cursorTextField = [self detailTextFieldWithText:palette.cursorColor monospaced:YES];
+        _paletteTextFields[i].cursorTextField.accessibilityLabel = @"Cursor Color";
         NSMutableArray<UITextField *> *textFields = [NSMutableArray new];
         for (int j = 0; j < COLORS; ++j) {
             UITextField *textField = [self detailTextFieldWithText:palette.colorPaletteOverrides ? palette.colorPaletteOverrides[j] : nil monospaced: YES];
+            textField.accessibilityLabel = [NSString stringWithFormat:@"Color %d", j];
             textField.autocorrectionType = UITextAutocorrectionTypeNo;
             textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
             [textFields addObject:textField];

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8158,6 +8158,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField = [UITextField new];
     _addressField.translatesAutoresizingMaskIntoConstraints = NO;
     _addressField.delegate = self;
+    _addressField.accessibilityLabel = @"Address";
     _addressField.clearButtonMode = UITextFieldViewModeWhileEditing;
     _addressField.returnKeyType = UIReturnKeyGo;
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
💡 **What:** Added `accessibilityLabel` properties to `UITextField` instances in `ThemeViewController.m` and `WorkspaceViewController.m` that previously had none.
🎯 **Why:** To ensure screen reader users (VoiceOver) can understand the purpose of inputs like the browser address bar and theme color customization fields.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Address", "Theme Name", "Foreground Color", "Background Color", "Cursor Color", and "Color [X]" when these respective fields are focused, rather than simply announcing "Text field".

---
*PR created automatically by Jules for task [188568117390581044](https://jules.google.com/task/188568117390581044) started by @emkey1*