### PR TITLE
⚡ Bolt: Remove O(N^2) strcat usage for performance improvement

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");

--- a/linux/main.c
+++ b/linux/main.c
@@ -8,11 +8,18 @@ extern void run_kernel(void);
 int main(int argc, const char *argv[])
 {
 	int i;
+	size_t len = 0;
 	for (i = 1; i < argc; i++) {
-		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+		if (i > 1 && len < sizeof(boot_command_line) - 1) {
+			boot_command_line[len++] = ' ';
+		}
+		size_t arg_len = strlen(argv[i]);
+		if (len + arg_len < sizeof(boot_command_line)) {
+			memcpy(boot_command_line + len, argv[i], arg_len);
+			len += arg_len;
+		}
 	}
+	boot_command_line[len] = '\0';
 	run_kernel();
 	for (;;) host_pause();
 	return 0;


### PR DESCRIPTION
💡 **What**: Replaced dynamic string construction using `strcat` with explicit length tracking and `memcpy` in `fs/proc/pid.c` (cgroup tracking) and `linux/main.c` (kernel arguments).
🎯 **Why**: Because `strcat` traverses the entire accumulated string to find the null terminator on every append, it causes an O(N^2) performance degradation which scales poorly with large lists of arguments or heavily nested cgroups.
📊 **Impact**: Reduces string concatenation time complexity from O(N^2) to O(N) by keeping append operations O(1). Additionally, the change to `linux/main.c` fixes a potential buffer overflow by properly bounds checking `boot_command_line`.
🔬 **Measurement**: The performance of heavily nested cgroup traversal and large argument parsing is improved. Correctness was verified by ensuring tests still pass.

---
*PR created automatically by Jules for task [4024241191910960510](https://jules.google.com/task/4024241191910960510) started by @emkey1*