### PR TITLE
🎨 Palette: Add accessibility label to browser address field

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8158,6 +8158,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField = [UITextField new];
     _addressField.translatesAutoresizingMaskIntoConstraints = NO;
     _addressField.delegate = self;
+    _addressField.accessibilityLabel = @"Address or Search";
     _addressField.clearButtonMode = UITextFieldViewModeWhileEditing;
     _addressField.returnKeyType = UIReturnKeyGo;
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
💡 What: Added an explicit `accessibilityLabel` to the browser address field in `WorkspaceViewController`.
🎯 Why: The `UITextField` used for the browser address lacks a persistent adjacent text label. Without an explicit accessibility label, VoiceOver users will just hear "text field", making its purpose unclear.
📸 Before/After: Visuals remain unchanged. VoiceOver now reads "Address or Search" when focusing the address field.
♿ Accessibility: Improves screen reader navigation and clarity.

---
*PR created automatically by Jules for task [530907750241158754](https://jules.google.com/task/530907750241158754) started by @emkey1*