### PR TITLE
🎨 Palette: Add accessibility trait for active desktop

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -7690,6 +7690,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     jump.backgroundColor = active ? [accent colorWithAlphaComponent:0.22] : nil;
     [jump setTitle:[NSString stringWithFormat:@"Desktop %ld", (long)(index + 1)] forState:UIControlStateNormal];
     [jump setTitleColor:active ? accent : (theme[@"primary"] ?: UIColor.darkTextColor) forState:UIControlStateNormal];
+    if (active) {
+        jump.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        jump.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     [jump.heightAnchor constraintEqualToConstant:ISHWorkspaceUsesPhoneLayout() ? 30.0 : 38.0].active = YES;
     [jump addTarget:self action:@selector(jumpToDesktopFromApplet:) forControlEvents:UIControlEventTouchUpInside];
     [row addArrangedSubview:jump];


### PR DESCRIPTION
💡 What: The UX enhancement added: Added `UIAccessibilityTraitSelected` to the active desktop button in the workspace menu.
🎯 Why: The user problem it solves: Screen reader users could not determine which desktop was currently active, as the state was only communicated visually via color.
📸 Before/After: Visuals unchanged. VoiceOver now announces "Selected" for the active desktop button.
♿ Accessibility: Ensures VoiceOver accurately communicates the active state of desktops, matching the visual indication.

---
*PR created automatically by Jules for task [3234163265631810023](https://jules.google.com/task/3234163265631810023) started by @emkey1*