### PR TITLE
⚡ Bolt: Replace O(N) strcat with O(1) memcpy in proc_pid_cgroup_show

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");


### PR DESCRIPTION
**💡 What:** Replaced `strcat(seen, key)` with `memcpy(seen + seen_len, key, n + 2)` and length tracking in `proc_pid_cgroup_show`.
**🎯 Why:** Repeatedly calling `strcat` inside a loop requires O(N) recalculations of string length on every iteration, leading to O(N²) time complexity when building the cgroup deduplication string.
**📊 Impact:** Reduces the time complexity of the append operation from O(N) to O(1), improving CPU efficiency when generating `/proc/<pid>/cgroup` for tasks with many cgroup namespaces.
**🔬 Measurement:** Verified using the test suite. No functional changes; purely a performance optimization. Memory bounds are identical to the original logic (`< sizeof(seen)`).

---
*PR created automatically by Jules for task [15290100817788662364](https://jules.google.com/task/15290100817788662364) started by @emkey1*