### PR TITLE
🎨 Palette: Add accessibility labels to unlabeled UITextFields

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -1289,6 +1289,7 @@ static NSAttributedString *ISHLLMAttributedStringFromMarkdown(NSString *markdown
     _promptField.borderStyle = UITextBorderStyleRoundedRect;
     _promptField.placeholder = @"Ask the configured model";
     _promptField.returnKeyType = UIReturnKeySend;
+    _promptField.accessibilityLabel = @"Prompt input";
     _promptField.autocorrectionType = UITextAutocorrectionTypeDefault;
     _promptField.delegate = self;
     [inputBar addSubview:_promptField];

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8968,6 +8968,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField.delegate = self;
     _addressField.clearButtonMode = UITextFieldViewModeWhileEditing;
     _addressField.returnKeyType = UIReturnKeyGo;
+    _addressField.accessibilityLabel = @"Address bar";
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     _addressField.autocorrectionType = UITextAutocorrectionTypeNo;
     _addressField.spellCheckingType = UITextSpellCheckingTypeNo;


### PR DESCRIPTION
💡 What: Added explicit `accessibilityLabel` properties to `_addressField` in `WorkspaceViewController` and `_promptField` in `AboutViewController`.
🎯 Why: Text fields that act as standalone inputs without visible textual labels (like a browser address bar or a prompt input field) are difficult for VoiceOver users to identify and understand without an explicit accessibility label.
📸 Before/After: N/A (Non-visual change).
♿ Accessibility: Improves screen reader support by ensuring VoiceOver clearly announces "Address bar" and "Prompt input" when focusing on these `UITextField`s, allowing visually impaired users to understand their purpose without relying on visual context or placeholders.

---
*PR created automatically by Jules for task [9734377281259660137](https://jules.google.com/task/9734377281259660137) started by @emkey1*