### PR TITLE
⚡ Bolt: Optimize string concatenation in proc_pid_cgroup_show

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");


### PR DESCRIPTION
### 💡 What
Optimized dynamic string concatenation inside the loop in `proc_pid_cgroup_show` (`fs/proc/pid.c`) by replacing `strcat` with explicit length tracking and `memcpy`.

### 🎯 Why
In performance-critical VFS loops, using `strcat` repeatedly on an accumulating buffer causes O(N^2) overhead because `strcat` must scan the string from the beginning to find the null terminator on every single iteration. We already know the size of the appended chunk, so we can avoid this.

### 📊 Impact
Eliminates redundant O(N) string length recalculations during the deduplication of mounted hierarchies in cgroup procfs reporting, reducing CPU overhead during system monitoring and enumeration tasks (e.g. `htop`, `ps`).

### 🔬 Measurement
Tests via the e2e test suite (`./tests/e2e/e2e.bash`) passed locally, verifying correct deduplication and string construction. Code was manually reviewed to verify safety (bounds checking remains robust).

---
*PR created automatically by Jules for task [7668706699270311818](https://jules.google.com/task/7668706699270311818) started by @emkey1*