### PR TITLE
🎨 Palette: [Accessibility] Add label to address field

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8976,6 +8976,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         _addressField.smartQuotesType = UITextSmartQuotesTypeNo;
         _addressField.smartInsertDeleteType = UITextSmartInsertDeleteTypeNo;
     }
+    _addressField.accessibilityLabel = @"Address";
     [_addressContainerView addSubview:_addressField];
 
     _progressView = [self workspaceThemeProgressView];


### PR DESCRIPTION
💡 What: Added an `accessibilityLabel` of "Address" to the `_addressField` in `WorkspaceViewController`.
🎯 Why: VoiceOver users will now have clear context that the `UITextField` is an address bar instead of an unlabeled text field.
📸 Before/After: Visuals are unchanged.
♿ Accessibility: The address text field is now properly announced by VoiceOver as "Address, Text field".

---
*PR created automatically by Jules for task [2836698433416742834](https://jules.google.com/task/2836698433416742834) started by @emkey1*