### PR TITLE
🎨 Palette: Add accessibility labels to main text fields

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -1289,6 +1289,7 @@ static NSAttributedString *ISHLLMAttributedStringFromMarkdown(NSString *markdown
     _promptField.borderStyle = UITextBorderStyleRoundedRect;
     _promptField.placeholder = @"Ask the configured model";
     _promptField.returnKeyType = UIReturnKeySend;
+    _promptField.accessibilityLabel = @"Ask the configured model";
     _promptField.autocorrectionType = UITextAutocorrectionTypeDefault;
     _promptField.delegate = self;
     [inputBar addSubview:_promptField];

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8971,6 +8971,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     _addressField.autocorrectionType = UITextAutocorrectionTypeNo;
     _addressField.spellCheckingType = UITextSpellCheckingTypeNo;
+    _addressField.accessibilityLabel = @"Address and Search";
     if (@available(iOS 11.0, *)) {
         _addressField.smartDashesType = UITextSmartDashesTypeNo;
         _addressField.smartQuotesType = UITextSmartQuotesTypeNo;


### PR DESCRIPTION
💡 What: Added VoiceOver accessibility labels (`accessibilityLabel`) to the URL address bar in `WorkspaceViewController` and the LLM prompt field in `AboutViewController`.
🎯 Why: Text fields that don't have adjacent visible textual labels (like standard forms do) just read out their placeholder text or nothing to screen reader users, making it hard to identify their core purpose. Adding explicit accessibility labels resolves this.
📸 Before/After: Visuals remain unchanged. VoiceOver now reads "Address and Search" for the browser bar and "Ask the configured model" for the prompt field instead of just the placeholder/value.
♿ Accessibility: Improved screen reader navigation and clarity for core inputs.

---
*PR created automatically by Jules for task [10811770308114783459](https://jules.google.com/task/10811770308114783459) started by @emkey1*