### PR TITLE
⚡ Bolt: Optimize cgroup deduplication string tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2026-03-27 - Hoist string length calculations in sys_getcwd_common
 **Learning:** In `kernel/fs.c`, `sys_getcwd_common` repeatedly called `strlen(pwd)` to determine the length of the current working directory string. This caused unnecessary O(N) traversals per operation, scaling poorly for long paths.
 **Action:** When a string's length needs to be used multiple times in an inner function, compute the length once and cache it in a variable (`pwd_len`) rather than recalculating it internally.
+## 2026-03-29 - Optimize cgroup hierarchy deduplication
+**Learning:** In `fs/proc/pid.c`, string tracking for deduplicated cgroup hierarchies used `strcat` into a `seen` buffer, resulting in repeated O(N) operations.
+**Action:** Replace `strcat` with explicit tracking of the length of the string buffer (`seen_len`) and `memcpy` to append to the end of the string.

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");


### PR DESCRIPTION
💡 What: Replaced the O(N) `strcat` call in the cgroup hierarchy deduplication loop in `fs/proc/pid.c` with O(1) direct memory assignment (`memcpy`) utilizing an explicitly tracked `seen_len` variable.
🎯 Why: `strcat` recalculates the string's length by scanning from the beginning every time it's called, causing O(N^2) complexity over the loop. For the `seen` buffer tracking multiple cgroup controllers, this causes unnecessary performance overhead.
📊 Impact: Changes O(N) string appends to O(1) pointer-offset copies, removing the redundant length calculations on the `seen` string buffer.
🔬 Measurement: Verify correctness by inspecting `/proc/<pid>/cgroup` for deduplicated output; there should be no functional change, but the processing time internally will be reduced.

---
*PR created automatically by Jules for task [17931233757752550828](https://jules.google.com/task/17931233757752550828) started by @emkey1*