### PR TITLE
🎨 Palette: Apply UIAccessibilityTraitSelected to active desktop button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8460,6 +8460,11 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     jump.layer.borderColor = (theme[@"stroke"] ?: [UIColor colorWithWhite:0.5 alpha:0.35]).CGColor;
     jump.backgroundColor = active ? [accent colorWithAlphaComponent:0.22] : nil;
     [jump setTitle:[NSString stringWithFormat:@"Desktop %ld", (long)(index + 1)] forState:UIControlStateNormal];
+    if (active) {
+        jump.accessibilityTraits |= UIAccessibilityTraitSelected;
+    } else {
+        jump.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+    }
     [jump setTitleColor:active ? accent : (theme[@"primary"] ?: UIColor.darkTextColor) forState:UIControlStateNormal];
     [jump.heightAnchor constraintEqualToConstant:ISHWorkspaceUsesPhoneLayout() ? 30.0 : 38.0].active = YES;
     [jump addTarget:self action:@selector(jumpToDesktopFromApplet:) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
💡 What: Added `UIAccessibilityTraitSelected` to the active desktop button in the Workspace UI.
🎯 Why: To ensure screen reader users are aware of which desktop is currently selected, as the state was previously only communicated visually.
📸 Before/After: Not a visual change.
♿ Accessibility: The VoiceOver experience now accurately reflects the selected state of desktop buttons.

---
*PR created automatically by Jules for task [11550775004357627385](https://jules.google.com/task/11550775004357627385) started by @emkey1*