### PR TITLE
⚡ Bolt: Optimize strcat to memcpy in loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2026-03-27 - Hoist string length calculations in sys_getcwd_common
 **Learning:** In `kernel/fs.c`, `sys_getcwd_common` repeatedly called `strlen(pwd)` to determine the length of the current working directory string. This caused unnecessary O(N) traversals per operation, scaling poorly for long paths.
 **Action:** When a string's length needs to be used multiple times in an inner function, compute the length once and cache it in a variable (`pwd_len`) rather than recalculating it internally.
+
+## 2026-07-03 - Optimize strcat to memcpy with length tracking
+**Learning:** Using `strcat` repeatedly inside loops for dynamic string accumulation (e.g., in `linux/main.c` and `fs/proc/pid.c`) causes O(N^2) time complexity because `strcat` traverses the entire accumulated string every time to find the null terminator.
+**Action:** Replace repeated `strcat` calls inside loops with `memcpy` and a running length tracker variable (`len`). This reduces the time complexity to O(N) while maintaining safety, but remember to declare new tracking variables at the top of their scope to preserve C89 compatibility.

--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,11 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            // Optimize strcat to memcpy with length tracking (O(N) instead of O(N^2))
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");

--- a/linux/main.c
+++ b/linux/main.c
@@ -8,10 +8,16 @@ extern void run_kernel(void);
 int main(int argc, const char *argv[])
 {
 	int i;
+	// Optimize strcat to memcpy with length tracking (O(N) instead of O(N^2))
+	size_t len = 0;
 	for (i = 1; i < argc; i++) {
-		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+		size_t arg_len = strlen(argv[i]);
+		if (i > 1) {
+			boot_command_line[len++] = ' ';
+			boot_command_line[len] = '\0';
+		}
+		memcpy(boot_command_line + len, argv[i], arg_len + 1);
+		len += arg_len;
 	}
 	run_kernel();
 	for (;;) host_pause();


### PR DESCRIPTION
💡 What: Replaced repeated `strcat` calls in `linux/main.c` and `fs/proc/pid.c` with `memcpy` using a running length tracker.
🎯 Why: Using `strcat` repeatedly inside loops causes O(N^2) time complexity because `strcat` must traverse the entire accumulated string every time to find the null terminator. 
📊 Impact: Reduces time complexity of string accumulation in these loops from O(N^2) to O(N).
🔬 Measurement: Verified functionality by compiling and running tests, confirming no regressions. Code inspection shows string concatenation no longer repeats full length traversal.

---
*PR created automatically by Jules for task [12111786796482443827](https://jules.google.com/task/12111786796482443827) started by @emkey1*