### PR TITLE
🎨 Palette: Add accessibility labels to text fields

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -1288,6 +1288,7 @@ static NSAttributedString *ISHLLMAttributedStringFromMarkdown(NSString *markdown
     _promptField.translatesAutoresizingMaskIntoConstraints = NO;
     _promptField.borderStyle = UITextBorderStyleRoundedRect;
     _promptField.placeholder = @"Ask the configured model";
+    _promptField.accessibilityLabel = @"Prompt input";
     _promptField.returnKeyType = UIReturnKeySend;
     _promptField.autocorrectionType = UITextAutocorrectionTypeDefault;
     _promptField.delegate = self;

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -8971,6 +8971,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     _addressField.autocorrectionType = UITextAutocorrectionTypeNo;
     _addressField.spellCheckingType = UITextSpellCheckingTypeNo;
+    _addressField.accessibilityLabel = @"Address bar";
+    _addressField.accessibilityLabel = @"Address bar";
     if (@available(iOS 11.0, *)) {
         _addressField.smartDashesType = UITextSmartDashesTypeNo;
         _addressField.smartQuotesType = UITextSmartQuotesTypeNo;


### PR DESCRIPTION
💡 **What**: Added explicit `accessibilityLabel` properties to `_addressField` in `WorkspaceViewController` and `_promptField` in `AboutViewController`.
🎯 **Why**: Interactive input elements like text fields that lack adjacent visible labels must provide an explicit accessibility label for screen readers to identify their purpose. Without it, VoiceOver simply announces the field role, leaving users confused about what input is expected.
📸 **Before/After**: VoiceOver no longer just announces "Text Field". It now announces "Address bar, Text Field" or "Prompt input, Text Field".
♿ **Accessibility**: Significant improvement for VoiceOver users navigating the workspace browser and the LLM prompt interface.

---
*PR created automatically by Jules for task [7014899060479171448](https://jules.google.com/task/7014899060479171448) started by @emkey1*