### PR TITLE
build(deps): bump faraday 1.10.5 → 1.10.6 (CVE-2026-54297, high)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
Addresses Dependabot alert [#17](https://github.com/emkey1/ish-AOK/security/dependabot/17).

## Vulnerability
- **CVE-2026-54297** / **GHSA-98m9-hrrm-r99r** — high severity
- `Faraday::NestedParamsEncoder` decodes nested query strings with **no depth limit**. A crafted `a[x][x][x]...[x]=1` builds a deeply nested Ruby `Hash`; the recursive `dehash` walk raises an uncaught `SystemStackError` (`stack level too deep`) — a stack-exhaustion **DoS**.
- Vulnerable range: `>= 1.0.0, <= 1.10.5`. Patched in **1.10.6** (backport) / 2.14.3 (2.x line).

## Fix
Lockfile-only bump `faraday 1.10.5 → 1.10.6`.

- faraday is a **transitive dev dependency** (`fastlane` → octokit/etc.); it is not used by the emulator at runtime.
- The tightest constraint in the tree is `faraday (~> 1.0)`, so it must stay on the **1.x** line — `1.10.6` is the backported patch and the newest 1.x release.
- faraday 1.10.6’s runtime dependency set is **identical** to 1.10.5, so only the version string changes; every reverse-dependency range (`>= 0.8.0`, `~> 1.0`, `>= 1.0, < 3.a`, `>= 0.17.5, < 3.a`) still resolves. No `CHECKSUMS`/`BUNDLED WITH` changes.

## Diff
```
-    faraday (1.10.5)
+    faraday (1.10.6)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)