### PR TITLE
⚡ Bolt: Cache getenv lookup on hot faccessat path

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -286,12 +286,20 @@ static dword_t sys_faccessat_common(fd_t at_f, guest_addr_t path_addr, mode_t_ m
         return _EBADF;
     STRACE("faccessat(%d, \"%s\", 0x%x, %d)", at_f, path, mode, flags);
 
-    bool trace_dpkg = getenv("ISH_TRACE_DPKG_STAT") != NULL &&
+    // ⚡ Bolt: Cache the environment lookup to avoid an expensive getenv()
+    // call on every single faccessat execution (a hot path).
+    static int trace_dpkg_env = -1;
+    if (trace_dpkg_env == -1)
+        trace_dpkg_env = getenv("ISH_TRACE_DPKG_STAT") != NULL;
+
+    // ⚡ Bolt: Use sizeof() instead of strlen() for string literal
+    // to avoid O(N) string traversal at runtime.
+    bool trace_dpkg = trace_dpkg_env &&
         current != NULL &&
         (strncmp(current->comm, "dpkg", 4) == 0 ||
          strcmp(current->comm, "apt") == 0 ||
          strcmp(current->comm, "apt-get") == 0) &&
-        strncmp(path, "/var/lib/dpkg/", strlen("/var/lib/dpkg/")) == 0;
+        strncmp(path, "/var/lib/dpkg/", sizeof("/var/lib/dpkg/") - 1) == 0;
 
     if (flags & ~FACCESSAT_ALLOWED_FLAGS_)
         return _EINVAL;


### PR DESCRIPTION
💡 What: Cache the `ISH_TRACE_DPKG_STAT` environment variable in a static variable, and replace `strlen("/var/lib/dpkg/")` with `sizeof("/var/lib/dpkg/") - 1` in `sys_faccessat_common`. Added explanatory comments per Bolt rules.
🎯 Why: `sys_faccessat_common` (and by extension `faccessat()` and `access()`) is a very hot path during file system traversal. `getenv()` has to search an array and perform string comparisons, which introduces significant overhead when called on every single execution. `strlen()` also causes redundant O(N) evaluation at runtime.
📊 Impact: Reduces overhead on the hot `access()`/`faccessat()` syscall path by moving the environment lookup to a one-time operation, significantly speeding up file access operations when the flag is disabled (the default).
🔬 Measurement: Run a tight loop of `access()` calls on a file and profile the CPU usage; time spent in `getenv` within `sys_faccessat_common` drops to zero after the first execution.

---
*PR created automatically by Jules for task [8647748469498081971](https://jules.google.com/task/8647748469498081971) started by @emkey1*