### PR TITLE
⚡ Bolt: Avoid O(N^2) dynamic string concatenation in main and procfs

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -563,6 +563,7 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
     // ENODATA ("Cannot determine cgroup we are running in").
     int next_id = 1;
     char seen[512] = "|";
+    size_t seen_len = 1;
     struct mount *mount;
     list_for_each_entry(&mounts, mount, mounts) {
         if (strcmp(mount->fs->name, "cgroup") != 0)
@@ -582,8 +583,10 @@ static int proc_pid_cgroup_show(struct proc_entry *UNUSED(entry), struct proc_da
         key[n + 1] = '\0';
         if (strstr(seen, key) != NULL)
             continue;
-        if (strlen(seen) + n + 1 < sizeof(seen))
-            strcat(seen, key);
+        if (seen_len + n + 1 < sizeof(seen)) {
+            memcpy(seen + seen_len, key, n + 2);
+            seen_len += n + 1;
+        }
         proc_printf(buf, "%d:%s:/\n", next_id++, controller);
     }
     proc_printf(buf, "0::/\n");

--- a/linux/main.c
+++ b/linux/main.c
@@ -8,10 +8,14 @@ extern void run_kernel(void);
 int main(int argc, const char *argv[])
 {
 	int i;
+	size_t len = 0;
 	for (i = 1; i < argc; i++) {
+		size_t arg_len;
+		arg_len = strlen(argv[i]);
 		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+			boot_command_line[len++] = ' ';
+		memcpy(boot_command_line + len, argv[i], arg_len + 1);
+		len += arg_len;
 	}
 	run_kernel();
 	for (;;) host_pause();


### PR DESCRIPTION
💡 What: Replaced `strcat` with explicit length calculations using `memcpy` when constructing `boot_command_line` and the `seen` cgroup array.
🎯 Why: `strcat` inside a loop leads to O(N^2) time complexity because it must traverse the entire existing string to find the end for every append. By explicitly tracking the total length and using `memcpy`, we reduce the complexity to O(N), minimizing CPU overhead during application boot and procfs reads.
📊 Impact: Reduces string processing overhead during initialization and `cgroup` enumeration in `sys_read`.
🔬 Measurement: Verify tests still pass and BSS arrays are populated safely using explicit string boundaries.

---
*PR created automatically by Jules for task [18304889329328626953](https://jules.google.com/task/18304889329328626953) started by @emkey1*