### PR TITLE
🎨 Palette: Add accessibilityLabel to browser address field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-06-03 - Dynamic Accessibility Labels for State-Changing Buttons
 **Learning:** In iOS UI development, when a single button dynamically changes its visual icon and primary function based on state (e.g., setting a new title or action dynamically), its `accessibilityLabel` must be dynamically updated alongside the visual change to accurately describe the current actionable state to VoiceOver users.
 **Action:** When updating a button's visual representation (e.g., via `setTitle:`), ensure you also dynamically update `accessibilityLabel` to match the new state or function.
+
+## 2024-06-04 - Accessibility Labels for Input Fields Without Visible Labels
+**Learning:** In iOS UI development, interactive input elements like `UITextField` that lack adjacent visible textual labels (such as a browser address bar) must have an explicitly set `accessibilityLabel` to ensure VoiceOver users can clearly identify their purpose.
+**Action:** Always add an `accessibilityLabel` to `UITextField` or similar input controls when they don't have a visible label nearby.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11276,6 +11276,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         _addressField.smartQuotesType = UITextSmartQuotesTypeNo;
         _addressField.smartInsertDeleteType = UITextSmartInsertDeleteTypeNo;
     }
+    _addressField.accessibilityLabel = @"Address";
     [_addressContainerView addSubview:_addressField];
 
     _progressView = [self workspaceThemeProgressView];


### PR DESCRIPTION
💡 **What**: Added `accessibilityLabel` to the `_addressField` in `WorkspaceViewController.m`.
🎯 **Why**: The address bar in the workspace browser is a `UITextField` without a visible textual label adjacent to it. Without an explicit accessibility label, VoiceOver users receive no context about what the field is for when it receives focus.
📸 **Before/After**: N/A (Non-visual accessibility change)
♿ **Accessibility**: Screen readers (like VoiceOver) will now correctly announce "Address" when the user focuses the address input field.

---
*PR created automatically by Jules for task [13487284302396461203](https://jules.google.com/task/13487284302396461203) started by @emkey1*