### PR TITLE
⚡ Bolt: Optimize boot_command_line concatenation in main.c

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,6 @@
 ## 2026-03-27 - Hoist string length calculations in sys_getcwd_common
 **Learning:** In `kernel/fs.c`, `sys_getcwd_common` repeatedly called `strlen(pwd)` to determine the length of the current working directory string. This caused unnecessary O(N) traversals per operation, scaling poorly for long paths.
 **Action:** When a string's length needs to be used multiple times in an inner function, compute the length once and cache it in a variable (`pwd_len`) rather than recalculating it internally.
+## 2026-07-06 - Optimize string concatenation in main
+**Learning:** In `linux/main.c`, the `main` function used `strcat` to append command line arguments into `boot_command_line`, which causes O(N) recalculations of string length since `strcat` must traverse the string to find the null terminator every time.
+**Action:** Replace `strcat` with `memcpy` and explicit string length tracking using a `len` variable. By keeping track of the current string length `len`, appending becomes an O(1) operation.

--- a/linux/main.c
+++ b/linux/main.c
@@ -8,10 +8,15 @@ extern void run_kernel(void);
 int main(int argc, const char *argv[])
 {
 	int i;
+	size_t len = 0;
 	for (i = 1; i < argc; i++) {
-		if (i > 1)
-			strcat(boot_command_line, " ");
-		strcat(boot_command_line, argv[i]);
+		size_t arg_len = strlen(argv[i]);
+		if (i > 1) {
+			boot_command_line[len++] = ' ';
+		}
+		memcpy(boot_command_line + len, argv[i], arg_len);
+		len += arg_len;
+		boot_command_line[len] = '\0';
 	}
 	run_kernel();
 	for (;;) host_pause();


### PR DESCRIPTION
* 💡 What: The optimization replaces O(N^2) dynamic string concatenation via `strcat` with O(N) linear iteration using `memcpy` and explicit tracking of `boot_command_line` length in `linux/main.c`.
* 🎯 Why: `strcat` requires scanning the destination string from the beginning to find the null terminator, creating O(N^2) complexity.
* 📊 Impact: Improves startup performance linearly with the size of arguments passed. Reduces command-line parsing latency to O(N), where N is the total length of arguments.
* 🔬 Measurement: Observe reduction in instruction count and string scanning overhead during early boot / app launch when a high volume of arguments is present.

---
*PR created automatically by Jules for task [4142730864070200321](https://jules.google.com/task/4142730864070200321) started by @emkey1*