### PR TITLE
🎨 Palette: Add accessibility labels to text fields

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -1292,6 +1292,7 @@ static NSAttributedString *ISHLLMAttributedStringFromMarkdown(NSString *markdown
     _promptField.returnKeyType = UIReturnKeySend;
     _promptField.autocorrectionType = UITextAutocorrectionTypeDefault;
     _promptField.delegate = self;
+    _promptField.accessibilityLabel = @"Prompt input";
     [inputBar addSubview:_promptField];
 
     _sendButton = [UIButton buttonWithType:UIButtonTypeSystem];

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11271,6 +11271,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     _addressField.autocorrectionType = UITextAutocorrectionTypeNo;
     _addressField.spellCheckingType = UITextSpellCheckingTypeNo;
+    _addressField.accessibilityLabel = @"Address and Search Bar";
     if (@available(iOS 11.0, *)) {
         _addressField.smartDashesType = UITextSmartDashesTypeNo;
         _addressField.smartQuotesType = UITextSmartQuotesTypeNo;


### PR DESCRIPTION
🎨 Palette: Add accessibility labels to text fields

💡 What: Added `accessibilityLabel` properties to `_promptField` in `AboutViewController.m` and `_addressField` in `WorkspaceViewController.m`.
🎯 Why: VoiceOver users need descriptive context for text input fields that lack visible adjoining labels (like search bars or prompt inputs) to understand their purpose.
♿ Accessibility: The screen reader will now announce "Prompt input" instead of just "text field", and "Address and Search Bar" instead of just "text field".

---
*PR created automatically by Jules for task [3745166354671301160](https://jules.google.com/task/3745166354671301160) started by @emkey1*