### PR TITLE
🎨 Palette: [Accessibility] Add label to browser address field

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11276,6 +11276,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         _addressField.smartQuotesType = UITextSmartQuotesTypeNo;
         _addressField.smartInsertDeleteType = UITextSmartInsertDeleteTypeNo;
     }
+    _addressField.accessibilityLabel = @"Address";
     [_addressContainerView addSubview:_addressField];
 
     _progressView = [self workspaceThemeProgressView];


### PR DESCRIPTION
### 💡 What
Added an `accessibilityLabel` (`@"Address"`) to the `_addressField` in `WorkspaceViewController.m` where the browser URL is entered.

### 🎯 Why
Interactive input elements like `UITextField` that lack adjacent visible textual labels (such as a browser address bar) must have an explicitly set `accessibilityLabel` to ensure VoiceOver users can clearly identify their purpose. Without it, screen readers might only announce it as a generic text field.

### ♿ Accessibility
VoiceOver users navigating the workspace built-in browser will now hear "Address" when focusing on the URL field, clarifying its purpose.

---
*PR created automatically by Jules for task [1158638556819886345](https://jules.google.com/task/1158638556819886345) started by @emkey1*