### PR TITLE
Palette: Add accessibility label to About prompt field (resolves #452)

### DIFF
--- a/app/AboutViewController.m
+++ b/app/AboutViewController.m
@@ -1292,6 +1292,7 @@ static NSAttributedString *ISHLLMAttributedStringFromMarkdown(NSString *markdown
     _promptField.returnKeyType = UIReturnKeySend;
     _promptField.autocorrectionType = UITextAutocorrectionTypeDefault;
     _promptField.delegate = self;
+    _promptField.accessibilityLabel = @"Prompt input";
     [inputBar addSubview:_promptField];
 
     _sendButton = [UIButton buttonWithType:UIButtonTypeSystem];

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11274,7 +11274,6 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _addressField.translatesAutoresizingMaskIntoConstraints = NO;
     _addressField.accessibilityLabel = @"Address bar";
     _addressField.delegate = self;
-    _addressField.accessibilityLabel = @"Address";
     _addressField.clearButtonMode = UITextFieldViewModeWhileEditing;
     _addressField.returnKeyType = UIReturnKeyGo;
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
Adds the new content from #452 (_promptField.accessibilityLabel in
AboutViewController.m). Also fixes a leftover bug from #456: that PR
carried a redundant duplicate _addressField.accessibilityLabel set
(from rebasing #430 onto #426) that should have been dropped but
wasn't — removed here.

Closes #452.