### PR TITLE
🎨 Palette: [UX improvement] Workspace reload button accessibility label

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11667,7 +11667,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _closeTabButton.enabled = _tabWebViews.count > 1;
     _closeTabButton.alpha = _closeTabButton.enabled ? 1.0 : 0.42;
     [_reloadButton setTitle:(currentWebView.loading ? @"X" : @"R") forState:UIControlStateNormal];
-    _reloadButton.accessibilityLabel = currentWebView.loading ? @"Stop" : @"Reload";
+    NSString *reloadLabel = currentWebView.loading ? @"Stop loading" : @"Reload";
+    _reloadButton.accessibilityLabel = reloadLabel;
     _progressView.hidden = !currentWebView.loading && currentWebView.estimatedProgress >= 0.999;
     _progressView.alpha = _progressView.hidden ? 0.0 : 1.0;
     if (!_addressField.isFirstResponder) {


### PR DESCRIPTION
💡 What: Updated the accessibility label for the Workspace reload button to 'Stop loading' instead of just 'Stop' when a page is loading.
🎯 Why: To provide clearer context for VoiceOver users about the button's action.
📸 Before/After: N/A.
♿ Accessibility: The button now explicitly states 'Stop loading' which is more descriptive.

---
*PR created automatically by Jules for task [13253138613478096698](https://jules.google.com/task/13253138613478096698) started by @emkey1*