### PR TITLE
🎨 Palette: Add accessibility hint to home button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11493,6 +11493,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _reloadButton.accessibilityHint = @"Touch and hold to open the current page in Safari.";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _homeButton.accessibilityLabel = @"Home";
+    _homeButton.accessibilityHint = @"Touch and hold to change the home page.";
     _bookmarkButton = [self browserButtonWithTitle:@"☆" action:@selector(toggleBookmark:)];
     _bookmarkButton.accessibilityLabel = @"Bookmark";
     _bookmarkButton.accessibilityHint = @"Toggles a bookmark for the current page. Touch and hold to view bookmarks.";


### PR DESCRIPTION
🎨 Palette: Add accessibility hint to home button

💡 What: Added an `accessibilityHint` to the `_homeButton` in `WorkspaceViewController.m` to inform VoiceOver users that they can touch and hold the button to change their home page.
🎯 Why: The home button has a secondary long-press action (changing the home page), but this was not communicated to screen reader users. Adding an `accessibilityHint` ensures the interface is more intuitive and accessible.
♿ Accessibility: VoiceOver users will now hear "Touch and hold to change the home page." after the "Home" label, making the hidden functionality discoverable.

---
*PR created automatically by Jules for task [8444285950766774678](https://jules.google.com/task/8444285950766774678) started by @emkey1*