### PR TITLE
🎨 Palette: [UX improvement] Expand accessibility labels for icon-only audio controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-06-04 - Explicit Labels for Implicitly Grouped UI Controls
 **Learning:** In iOS UI development, interactive input elements like `UITextField` that lack adjacent visible textual labels (such as a browser address bar) must have an explicitly set `accessibilityLabel` to ensure VoiceOver users can clearly identify their purpose, even if placeholder text exists. Additionally, ensuring all controls in a toolbar (like 'Home' and 'Go' buttons) have `accessibilityLabel`s ensures a consistent experience for screen reader users.
 **Action:** When adding or modifying unlabeled input fields or icon/text buttons in toolbars, always set a clear `accessibilityLabel` property.
+
+## 2024-06-05 - Accessibility Labels for Factory-Generated Buttons
+**Learning:** When using a factory method to generate icon-only buttons with fallback text strings (like "M", "|<", ">|"), setting `accessibilityLabel` equal to the abbreviated fallback text does not provide enough context for VoiceOver users.
+**Action:** In button generation methods, expand abbreviated text placeholders into clear, descriptive `accessibilityLabel` values (e.g., mapping "M" to "Menu", ">|" to "Next Track") so VoiceOver users understand the button's purpose without relying on visual context.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -10067,6 +10067,25 @@ static UIColor *ISHAudioHexColor(uint32_t hex) {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     button.tintColor = tint;
+
+    NSString *accessibilityLabel = text;
+    if ([text isEqualToString:@"M"]) {
+        accessibilityLabel = @"Menu";
+    } else if ([text isEqualToString:@"|<"]) {
+        accessibilityLabel = @"Previous Track";
+    } else if ([text isEqualToString:@">|"]) {
+        accessibilityLabel = @"Next Track";
+    } else if ([text isEqualToString:@"VOL"]) {
+        accessibilityLabel = @"Volume";
+    } else if ([text isEqualToString:@">"]) {
+        accessibilityLabel = @"Play/Pause";
+    } else if ([text isEqualToString:@"S"]) {
+        accessibilityLabel = @"Shuffle";
+    } else if ([text isEqualToString:@"R"]) {
+        accessibilityLabel = @"Repeat";
+    }
+    button.accessibilityLabel = accessibilityLabel;
+
     BOOL haveSymbol = NO;
     if (symbol != nil) {
         if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
💡 **What**: Added explicit translation logic in `deviceSymbolButton:` to map abbreviated fallback text ("M", "|<", etc.) into descriptive `accessibilityLabel` strings.
🎯 **Why**: When icon-only buttons rely on short text fallbacks, those strings are announced by VoiceOver directly. Setting the label to "M" or ">|" provides insufficient context for visually impaired users.
📸 **Before/After**: No visual changes.
♿ **Accessibility**: Significant improvement for VoiceOver users, providing clear, descriptive labels for the audio playback controls (Menu, Previous Track, Next Track, Volume, Play/Pause, Shuffle, Repeat).

---
*PR created automatically by Jules for task [10710126025802387728](https://jules.google.com/task/10710126025802387728) started by @emkey1*