### PR TITLE
🎨 Palette: Add accessibilityHint to Home button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11620,6 +11620,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _reloadButton.accessibilityHint = @"Touch and hold to open the current page in Safari.";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _homeButton.accessibilityLabel = @"Home";
+    _homeButton.accessibilityHint = @"Touch and hold to change the home page.";
     _bookmarkButton = [self browserButtonWithTitle:@"☆" action:@selector(toggleBookmark:)];
     _bookmarkButton.accessibilityLabel = @"Bookmark";
     _bookmarkButton.accessibilityHint = @"Toggles a bookmark for the current page. Touch and hold to view bookmarks.";


### PR DESCRIPTION
💡 What: Added `accessibilityHint` to the Home button in the Workspace browser toolbar.
🎯 Why: The Home button has a secondary action (setting the home page) triggered by a long-press gesture, but VoiceOver users were previously not informed of this capability.
♿ Accessibility: Improves discoverability of secondary functionality for screen reader users by mirroring the pattern already used for the Reload and Bookmark buttons.

---
*PR created automatically by Jules for task [6326299712170616831](https://jules.google.com/task/6326299712170616831) started by @emkey1*