### PR TITLE
🎨 Palette: Add accessibilityHint to Home button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11682,6 +11682,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _reloadButton.accessibilityHint = @"Touch and hold to open the current page in Safari.";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _homeButton.accessibilityLabel = @"Home";
+    _homeButton.accessibilityHint = @"Opens the home page. Touch and hold to change the home page.";
     _bookmarkButton = [self browserButtonWithTitle:@"☆" action:@selector(toggleBookmark:)];
     _bookmarkButton.accessibilityLabel = @"Bookmark";
     _bookmarkButton.accessibilityHint = @"Toggles a bookmark for the current page. Touch and hold to view bookmarks.";


### PR DESCRIPTION
Added an `accessibilityHint` to the `_homeButton` in `WorkspaceViewController.m` to properly inform VoiceOver users of the secondary long-press action (changing the home page). This ensures a more consistent accessibility experience since neighboring toolbar buttons (`_reloadButton`, `_bookmarkButton`) already had hints for their long-press actions.

---
*PR created automatically by Jules for task [13616099225749870318](https://jules.google.com/task/13616099225749870318) started by @emkey1*