### PR TITLE
🎨 Palette: Add accessibility hint to Home button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -11682,6 +11682,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     _reloadButton.accessibilityHint = @"Touch and hold to open the current page in Safari.";
     _homeButton = [self browserButtonWithTitle:@"Home" action:@selector(goHome:)];
     _homeButton.accessibilityLabel = @"Home";
+    _homeButton.accessibilityHint = @"Touch and hold to set the home page.";
     _bookmarkButton = [self browserButtonWithTitle:@"☆" action:@selector(toggleBookmark:)];
     _bookmarkButton.accessibilityLabel = @"Bookmark";
     _bookmarkButton.accessibilityHint = @"Toggles a bookmark for the current page. Touch and hold to view bookmarks.";


### PR DESCRIPTION
💡 What: Added an accessibilityHint to the browser's Home button to explain the long-press behavior.
🎯 Why: VoiceOver users were previously unaware that they could long-press the Home button to change their home page.
📸 Before/After: N/A (Non-visual change).
♿ Accessibility: Improved discoverability of a secondary action for screen reader users.

---
*PR created automatically by Jules for task [4689454212195562589](https://jules.google.com/task/4689454212195562589) started by @emkey1*