### PR TITLE
🎨 Palette: Add accessibility hints to dock buttons

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -3485,6 +3485,7 @@ static UIView *ISHWorkspaceFindFirstResponder(UIView *view) {
     self.dockUtilsButton = [self workspaceDockTileButtonWithTitle:@"Utils"
                                                          selector:@selector(toggleClockFromDock:)
                                                        identifier:@"utils"];
+    self.dockUtilsButton.accessibilityHint = @"Touch and hold for utility options.";
     UILongPressGestureRecognizer *utilsLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleUtilsDockLongPress:)];
     utilsLongPressRecognizer.minimumPressDuration = 0.25;
@@ -3492,6 +3493,7 @@ static UIView *ISHWorkspaceFindFirstResponder(UIView *view) {
     self.dockTerminalButton = [self workspaceDockTileButtonWithTitle:@"Terminal"
                                                             selector:@selector(openOrFocusTerminalFromDock:)
                                                           identifier:ISHWorkspaceTerminalRoleSessionShell];
+    self.dockTerminalButton.accessibilityHint = @"Touch and hold for terminal options.";
     UILongPressGestureRecognizer *terminalLongPressRecognizer =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleTerminalDockLongPress:)];
     terminalLongPressRecognizer.minimumPressDuration = 0.25;


### PR DESCRIPTION
💡 **What:** Added `accessibilityHint` properties to `dockUtilsButton` and `dockTerminalButton`.
🎯 **Why:** To ensure VoiceOver users are aware of the hidden long-press functionality tied to these buttons.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** VoiceOver now reads out the secondary action available via long-press on these dock tiles, improving discoverability.

---
*PR created automatically by Jules for task [14225500156710630142](https://jules.google.com/task/14225500156710630142) started by @emkey1*