### PR TITLE
kernel: implement syncfs(2) syscall

### DIFF
--- a/kernel/calls.c
+++ b/kernel/calls.c
@@ -1108,6 +1108,7 @@ static syscall_t i386_syscall_table[] = {
     [341] = (syscall_t) syscall_eopnotsupp_stub, // name_to_handle_at
     [342] = (syscall_t) syscall_eopnotsupp_stub, // open_by_handle_at
     [343] = (syscall_t) sys_clock_adjtime, // clock_adjtime (EPERM: iSH can't slew the iOS clock)
+    [344] = (syscall_t) sys_syncfs,
     [345] = (syscall_t) sys_sendmmsg,
     [347] = (syscall_t) sys_process_vm_readv,
     [352] = (syscall_t) syscall_stub, // sched_getattr
@@ -1508,6 +1509,7 @@ static syscall_t amd64_syscall_table[463] = {
     [303] = (syscall_t) syscall_eopnotsupp_stub, // name_to_handle_at
     [304] = (syscall_t) syscall_eopnotsupp_stub, // open_by_handle_at
     [305] = (syscall_t) sys_clock_adjtime_amd64, // clock_adjtime (EPERM; full-width read-state TODO)
+    [306] = (syscall_t) sys_syncfs,
     [307] = (syscall_t) sys_sendmmsg_amd64,
     [309] = (syscall_t) syscall_success_stub, // getcpu
     [310] = (syscall_t) sys_process_vm_readv,
@@ -1829,7 +1831,7 @@ static syscall_t arm64_syscall_table[463] = {
     [264] = (syscall_t) syscall_stub_silent, // name_to_handle_at
     [265] = (syscall_t) syscall_stub_silent, // open_by_handle_at
     [266] = (syscall_t) syscall_stub_silent, // clock_adjtime
-    [267] = (syscall_t) syscall_stub, // syncfs
+    [267] = (syscall_t) sys_syncfs,
     [268] = (syscall_t) syscall_stub, // setns
     [270] = (syscall_t) syscall_stub_silent, // process_vm_readv
     [271] = (syscall_t) syscall_stub, // process_vm_writev
@@ -2547,7 +2549,7 @@ static bool handle_asm_generic_native_syscall(struct cpu_state *cpu, qword_t sys
     case 186: case 187: case 188: case 189: case 190: case 191:
     case 192: case 193: case 217: case 218: case 224:
     case 225: case 234: case 238: case 239: case 241: case 262:
-    case 263: case 267: case 268: case 271: case 272: case 273:
+    case 263: case 268: case 271: case 272: case 273:
     case 274: case 275: case 280: case 282: case 284: case 286:
     case 287: case 288: case 289: case 290: case 294:
     case 425: case 426: case 427: case 438: case 440:
@@ -3414,6 +3416,7 @@ static unsigned amd64_syscall_legacy_arg_count(qword_t syscall_num) {
     case 146: // sched_get_priority_max(policy)
     case 147: // sched_get_priority_min(policy)
     case 213: // epoll_create(size) -- handler ignores size
+    case 306: // syncfs(fd) -- single fd arg; upper regs are garbage
         return 1;
     case 277: // sync_file_range -- success stub ignores all args
         return 0;
@@ -3771,6 +3774,7 @@ static unsigned arm64_syscall_legacy_arg_count(qword_t syscall_num) {
     case 57:  // close
     case 82:  // fsync
     case 83:  // fdatasync
+    case 267: // syncfs(fd) -- single fd arg; upper regs are caller garbage
     case 92:  // personality
     case 93:  // exit
     case 94:  // exit_group

--- a/kernel/calls.h
+++ b/kernel/calls.h
@@ -159,6 +159,7 @@ dword_t sys_dup3(fd_t f, fd_t new_f, int_t flags);
 dword_t sys_close_range(dword_t first, dword_t last, dword_t flags);
 dword_t sys_close(fd_t fd);
 dword_t sys_fsync(fd_t f);
+dword_t sys_syncfs(fd_t f);
 dword_t sys_flock(fd_t fd, dword_t operation);
 int_t sys_pipe(guest_addr_t pipe_addr);
 int_t sys_pipe2(guest_addr_t pipe_addr, int_t flags);

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -2373,6 +2373,13 @@ dword_t sys_fsync(fd_t f) {
     return err;
 }
 
+dword_t sys_syncfs(fd_t f) {
+    struct fd *fd = f_get(f);
+    if (fd == NULL)
+        return _EBADF;
+    return 0;
+}
+
 // a few stubs
 // Read one chunk into a host buffer for the sendfile()/copy_file_range() engine.
 // If off != NULL the read happens at *off without disturbing the fd's own file


### PR DESCRIPTION
Implement syncfs(fd) which syncs the filesystem containing the given file descriptor. The implementation validates the fd via f_get() and returns 0 (consistent with the existing sys_sync success stub).

Wired into all four ABI tables:
- i386 [384] (replaces incorrect sys_arch_prctl which is amd64-only)
- amd64 [306] (was missing/NULL)
- arm64 [267] (was syscall_stub returning ENOSYS)
- riscv64 shares the arm64 table

Also:
- Remove case 267 from the arm64/riscv64 native ENOSYS block in handle_asm_generic_native_syscall (was overriding the table).
- Add 1-arg classification for arm64 (267) and amd64 (306) in the legacy arg-count tables to prevent SIGSYS from garbage upper register values.