### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix buffer overflow in /proc/pid.c

### DIFF
--- a/fs/proc/pid.c
+++ b/fs/proc/pid.c
@@ -666,7 +666,8 @@ void proc_maps_dump(struct task *task, struct proc_data *buf) {
             static const char s[] = "[stack]";
             memcpy(path, s, sizeof(s));
         } else if (data->name != NULL) {
-            strcpy(path, data->name);
+            strncpy(path, data->name, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
         } else if (data->fd != NULL) {
             generic_getpath(start_pt->data->fd, path);
         }
@@ -848,7 +849,8 @@ static void proc_smaps_walk(struct task *task, struct proc_data *buf, bool rollu
             static const char s[] = "[stack]";
             memcpy(path, s, sizeof(s));
         } else if (data->name != NULL) {
-            strcpy(path, data->name);
+            strncpy(path, data->name, sizeof(path) - 1);
+            path[sizeof(path) - 1] = '\0';
         } else if (data->fd != NULL) {
             generic_getpath(data->fd, path);
         }


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: Unbounded `strcpy` writing into fixed-size stack buffer `path[MAX_PATH]` in `fs/proc/pid.c` when building maps outputs.
* 🎯 Impact: Potential buffer overflow and kernel panic/arbitrary code execution if an attacker manages to create a file or mmap with a name exceeding MAX_PATH (4096 bytes).
* 🔧 Fix: Used bounds-checked `strncpy` and manually null-terminated the buffer.
* ✅ Verification: Ran formatting, lint checks, and the test suite. Verified compilation succeeds.

---
*PR created automatically by Jules for task [16822286899868741354](https://jules.google.com/task/16822286899868741354) started by @emkey1*