### PR TITLE
kernel: remove stale ENAMETOOLONG todo

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -338,8 +338,6 @@ int access_check(struct statbuf *stat, int check) {
     return 0;
 }
 
-// TODO ENAMETOOLONG
-
 #define AT_EACCESS_ 0x200
 #define FACCESSAT_ALLOWED_FLAGS_ (AT_EACCESS_ | AT_SYMLINK_NOFOLLOW_ | AT_EMPTY_PATH_)
 #define FCHMODAT2_ALLOWED_FLAGS_ (AT_SYMLINK_NOFOLLOW_ | AT_EMPTY_PATH_)


### PR DESCRIPTION
Removes the stale `// TODO ENAMETOOLONG` comment from kernel/fs.c:341. The ENAMETOOLONG case is already handled by `user_read_path` which returns `_ENAMETOOLONG` on truncation. The JIT overlength check was dropped per review feedback — it doesn't actually prevent execution since gadgets are already emitted by the time the check runs.