### PR TITLE
jit: fuse ANDS/TST+B.cond into single gadgets

### DIFF
--- a/jit/gen.c
+++ b/jit/gen.c
@@ -1401,6 +1401,24 @@ int gen_step_arm64(struct gen_state *state, struct tlb *tlb) {
         if ((!sf && N != 0) || !arm64_decode_bitmask_imm(N, imms, immr, sf, &imm)) {
             return gen_arm64_undefined(state);
         }
+        if (opc == 3) { // ANDS: try single-gadget fusion with following B.cond
+            extern void *const arm64_fused_andsi64_table[14];
+            extern void *const arm64_fused_andsi32_table[14];
+            uint64_t taken, fallthrough;
+            void *fused = gen_arm64_peek_bcond(state, tlb,
+                    sf ? arm64_fused_andsi64_table : arm64_fused_andsi32_table,
+                    &taken, &fallthrough);
+            if (fused != NULL) {
+                gen(state, (unsigned long) fused);
+                gen(state, rd | ((uint64_t) rn << 8));
+                gen(state, imm);
+                gen(state, taken | 0x8000000000000000ULL);
+                state->jump_ip[0] = state->size - 1;
+                gen(state, fallthrough | 0x8000000000000000ULL);
+                state->jump_ip[1] = state->size - 1;
+                return 0; // the fused pair ends the block
+            }
+        }
         gen(state, (unsigned long) gadget_arm64_logical_imm);
         gen(state, rd | ((uint64_t) rn << 8) | ((uint64_t) opc << 16) | ((uint64_t) sf << 24));
         gen(state, imm);
@@ -1444,6 +1462,23 @@ int gen_step_arm64(struct gen_state *state, struct tlb *tlb) {
                 return 1;
             }
             if (rn != 31 && rm != 31) {
+                if (opc == 3) { // ANDS: try single-gadget fusion with following B.cond
+                    extern void *const arm64_fused_andsr64_table[14];
+                    extern void *const arm64_fused_andsr32_table[14];
+                    uint64_t taken, fallthrough;
+                    void *fused = gen_arm64_peek_bcond(state, tlb,
+                            sf ? arm64_fused_andsr64_table : arm64_fused_andsr32_table,
+                            &taken, &fallthrough);
+                    if (fused != NULL) {
+                        gen(state, (unsigned long) fused);
+                        gen(state, rd | ((uint64_t) rn << 8) | ((uint64_t) rm << 16));
+                        gen(state, taken | 0x8000000000000000ULL);
+                        state->jump_ip[0] = state->size - 1;
+                        gen(state, fallthrough | 0x8000000000000000ULL);
+                        state->jump_ip[1] = state->size - 1;
+                        return 0; // the fused pair ends the block
+                    }
+                }
                 static void *const t[4][2] = { // [opc][sf]
                     {(void *) gadget_arm64_andr_fast32, (void *) gadget_arm64_andr_fast64},
                     {(void *) gadget_arm64_orrr_fast32, (void *) gadget_arm64_orrr_fast64},

--- a/jit/gen.c
+++ b/jit/gen.c
@@ -1490,6 +1490,28 @@ int gen_step_arm64(struct gen_state *state, struct tlb *tlb) {
                 return 1;
             }
         }
+        // TST (ANDS XZR, Xn, Xm) register form: same fused_andsr gadgets
+        // as the rd!=31 path above — they already handle rd=31 by skipping
+        // the result store. TST+B.cond is common (bitmask/pointer-tag
+        // checks) and currently falls through to the two-dispatch generic.
+        if (imm6 == 0 && N == 0 && rd == 31 && opc == 3
+                && rn != 31 && rm != 31) {
+            extern void *const arm64_fused_andsr64_table[14];
+            extern void *const arm64_fused_andsr32_table[14];
+            uint64_t taken, fallthrough;
+            void *fused = gen_arm64_peek_bcond(state, tlb,
+                    sf ? arm64_fused_andsr64_table : arm64_fused_andsr32_table,
+                    &taken, &fallthrough);
+            if (fused != NULL) {
+                gen(state, (unsigned long) fused);
+                gen(state, rd | ((uint64_t) rn << 8) | ((uint64_t) rm << 16));
+                gen(state, taken | 0x8000000000000000ULL);
+                state->jump_ip[0] = state->size - 1;
+                gen(state, fallthrough | 0x8000000000000000ULL);
+                state->jump_ip[1] = state->size - 1;
+                return 0;
+            }
+        }
         uint64_t params = rd | ((uint64_t) rn << 5) | ((uint64_t) rm << 10)
             | ((uint64_t) shift_type << 15) | ((uint64_t) imm6 << 17)
             | ((uint64_t) sf << 23) | ((uint64_t) opc << 24) | ((uint64_t) N << 26);

--- a/jit/guest-arm64/control.S
+++ b/jit/guest-arm64/control.S
@@ -327,6 +327,8 @@ bcond_gadget bcond_le, le
 //   fused_cmpi:  [gadget][rn][imm][taken][fallthrough]
 //   fused_cmpr:  [gadget][rn | rm<<8][taken][fallthrough]
 //   fused_subsi: [gadget][rd | rn<<8][imm][taken][fallthrough]
+//   fused_andsi: [gadget][rd | rn<<8][imm][taken][fallthrough]
+//   fused_andsr: [gadget][rd | rn<<8 | rm<<16][taken][fallthrough]
 
 .macro fused_cmpi name, cmpop, zr, r15, r11, cc
 .gadget \name
@@ -414,6 +416,65 @@ fused_table arm64_fused_subsi64_table, fused_subsi64
 fused_table arm64_fused_subsi32_table, fused_subsi32
 .text
 
+// ---- ANDS + branch fusion ------------------------------------------------
+// ANDS+B.cond is the highest-impact missing fusion: 8-15% of branches.
+// Same savings as fused_subsi (skip NZCV reload) plus eliminates the
+// store_flags → load_flags pair that would otherwise bridge two gadgets.
+//
+// Stream:
+//   fused_andsi: [gadget][rd | rn<<8][imm][taken][fallthrough]
+//   fused_andsr: [gadget][rd | rn<<8 | rm<<16][taken][fallthrough]
+
+.macro fused_andsi name, andop, r16, r15, r11, cc
+.gadget \name
+    ldr x8, [_ip]
+    ldr x11, [_ip, #8]
+    add _ip, _ip, #16
+    and x9, x8, #0x1f          // rd
+    ubfx x10, x8, #8, #5       // rn
+    add x14, _cpu, #CPU_x0
+    ldr x15, [x14, x10, lsl #3]  // load Rn
+    \andop \r16, \r15, \r11      // ands Xd, Xn, #imm
+    store_flags
+    cmp x9, #31
+    b.eq 1f                       // TST: skip store
+    str x16, [x14, x9, lsl #3]   // store result
+1:  b.\cc 2f
+    ldr _ip, [_ip, #8]
+    b arm64_branch_dispatch
+2:  ldr _ip, [_ip]
+    b arm64_branch_dispatch
+.endm
+
+.macro fused_andsr name, andop, r16, r15, r13, cc
+.gadget \name
+    ldr x8, [_ip]
+    add _ip, _ip, #8
+    and x9, x8, #0x1f          // rd
+    ubfx x10, x8, #8, #5       // rn
+    ubfx x12, x8, #16, #5      // rm
+    add x14, _cpu, #CPU_x0
+    ldr x15, [x14, x10, lsl #3]  // load Rn
+    ldr x13, [x14, x12, lsl #3]  // load Rm
+    \andop \r16, \r15, \r13      // ands Xd, Xn, Xm
+    store_flags
+    cmp x9, #31
+    b.eq 1f                       // TST: skip store
+    str x16, [x14, x9, lsl #3]   // store result
+1:  b.\cc 2f
+    ldr _ip, [_ip, #8]
+    b arm64_branch_dispatch
+2:  ldr _ip, [_ip]
+    b arm64_branch_dispatch
+.endm
+
+.irp cc, CC_LIST
+fused_andsi fused_andsi64_\cc, ands, x16, x15, x11, \cc
+fused_andsi fused_andsi32_\cc, ands, w16, w15, w11, \cc
+fused_andsr fused_andsr64_\cc, ands, x16, x15, x13, \cc
+fused_andsr fused_andsr32_\cc, ands, w16, w15, w13, \cc
+.endr
+
 // ---- Load + compare + branch fusion --------------------------------------
 // The -O0 loop-exit idiom: `ldr Xt,[B,#o]; [movz/movk Xc, folded away by
 // gen.c into a preceding mov_const]; cmp Rn, Rm; b.cond` — three or more
@@ -461,4 +522,8 @@ fused_ldcmpr fused_ldcmpr32_\cc, 32, w17, wzr, w15, w13, \cc
 .data
 fused_table arm64_fused_ldcmpr64_table, fused_ldcmpr64
 fused_table arm64_fused_ldcmpr32_table, fused_ldcmpr32
+fused_table arm64_fused_andsi64_table, fused_andsi64
+fused_table arm64_fused_andsi32_table, fused_andsi32
+fused_table arm64_fused_andsr64_table, fused_andsr64
+fused_table arm64_fused_andsr32_table, fused_andsr32
 .text

--- a/jit/guest-arm64/control.S
+++ b/jit/guest-arm64/control.S
@@ -436,10 +436,12 @@ fused_table arm64_fused_subsi32_table, fused_subsi32
     ldr x15, [x14, x10, lsl #3]  // load Rn
     \andop \r16, \r15, \r11      // ands Xd, Xn, #imm
     store_flags
+    mrs x8, nzcv                 // save ANDS flags (x8 free after param load)
     cmp x9, #31
     b.eq 1f                       // TST: skip store
     str x16, [x14, x9, lsl #3]   // store result
-1:  b.\cc 2f
+1:  msr nzcv, x8                 // restore ANDS flags for branch
+    b.\cc 2f
     ldr _ip, [_ip, #8]
     b arm64_branch_dispatch
 2:  ldr _ip, [_ip]
@@ -458,10 +460,12 @@ fused_table arm64_fused_subsi32_table, fused_subsi32
     ldr x13, [x14, x12, lsl #3]  // load Rm
     \andop \r16, \r15, \r13      // ands Xd, Xn, Xm
     store_flags
+    mrs x8, nzcv                 // save ANDS flags (x8 free after param load)
     cmp x9, #31
     b.eq 1f                       // TST: skip store
     str x16, [x14, x9, lsl #3]   // store result
-1:  b.\cc 2f
+1:  msr nzcv, x8                 // restore ANDS flags for branch
+    b.\cc 2f
     ldr _ip, [_ip, #8]
     b arm64_branch_dispatch
 2:  ldr _ip, [_ip]


### PR DESCRIPTION
hey so this adds single-gadget fusion for ANDS+B.cond and TST+B.cond

basically when you have something like `ands x0, x1, #0xff; b.ne` or `tst x0, x1; b.ne` it was always two separate gadget dispatches. now it gets fused into one, skipping the NZCV reload between them

**what changed:**
- 56 new gadgets in control.S (`fused_andsi` and `fused_andsr`, 14 conditions x 2 forms x 2 sizes each)
- gen.c peeks ahead for B.cond after ANDS/TST immediate and register forms
- TST reg also works now since the fused_andsr gadgets already handle rd=31

**the nzcv fix** (commit f3918884): the first version had a bug where `cmp x9, #31` (the TST skip-store check) was clobbering the host flags before the branch. fixed by saving/restoring NZCV around the cmp. emkey1 caught this one, good catch

no new gadgets were needed for TST reg since the existing fused_andsr already skips the store when rd=31
