### PR TITLE
kernel: fix vfork use-after-free and fatal signal handling

### DIFF
--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -446,12 +446,18 @@ static dword_t sys_clone_common(dword_t flags, guest_addr_t stack, guest_addr_t 
         // Same rule: the child returns 0 from clone in a0.
         task->cpu.riscv64_regs[riscv64_a0] = 0;
 
-    struct vfork_info vfork;
+    struct vfork_info *vfork = NULL;
     if (flags & CLONE_VFORK_) {
-        lock_init(&vfork.lock, "sys_clone\0");
-        cond_init(&vfork.cond);
-        vfork.done = false;
-        task->vfork = &vfork;
+        vfork = malloc(sizeof(struct vfork_info));
+        if (vfork == NULL) {
+            task_never_ran_destroy(task);
+            return _ENOMEM;
+        }
+        lock_init(&vfork->lock, "sys_clone\0");
+        cond_init(&vfork->cond);
+        vfork->done = false;
+        atomic_init(&vfork->refcount, 2); // parent + child
+        task->vfork = vfork;
     }
 
     // task might be destroyed by the time we finish, so save the pid
@@ -492,8 +498,11 @@ static dword_t sys_clone_common(dword_t flags, guest_addr_t stack, guest_addr_t 
         // ghost task linked in the pid table and thread-group lists.)
         task->vfork = NULL;
         task_never_ran_destroy(task);
-        if (flags & CLONE_VFORK_)
-            cond_destroy(&vfork.cond);
+        if (flags & CLONE_VFORK_) {
+            cond_destroy(&vfork->cond);
+            if (atomic_fetch_sub_explicit(&vfork->refcount, 1, memory_order_release) == 1)
+                free(vfork);
+        }
         return _EAGAIN;
     }
     if (trace_child)
@@ -509,15 +518,38 @@ static dword_t sys_clone_common(dword_t flags, guest_addr_t stack, guest_addr_t 
     }
 
     if (flags & CLONE_VFORK_) {
-        lock(&vfork.lock, 0);
-        while (!vfork.done)
-            // FIXME this should stop waiting if a fatal signal is received
-            wait_for_ignore_signals(&vfork.cond, &vfork.lock, NULL);
-        unlock(&vfork.lock);
+        bool fatal = false;
+        lock(&vfork->lock, 0);
+        while (!vfork->done) {
+            // Only break on fatal signals (default-terminate, no handler).
+            // Non-fatal signals must not interrupt vfork — the parent and
+            // child share the stack, so returning early would corrupt it.
+            lock(&current->sighand->lock, 0);
+            sigset_t_ pending = current->pending | current->sighand->pending;
+            pending &= ~current->blocked;
+            for (int sig = 1; sig <= 63 && !fatal; sig++) {
+                if (sigset_has(pending, sig)) {
+                    if (signal_action(current->sighand, sig) == SIGNAL_KILL)
+                        fatal = true;
+                }
+            }
+            unlock(&current->sighand->lock);
+            if (fatal)
+                break;
+            wait_for_ignore_signals(&vfork->cond, &vfork->lock, NULL);
+        }
+        unlock(&vfork->lock);
+
+        if (fatal)
+            send_signal(task, SIGKILL, SIGINFO_NIL);
+
         lock(&task->general_lock, 0);
         task->vfork = NULL;
         unlock(&task->general_lock);
-        cond_destroy(&vfork.cond);
+        if (atomic_fetch_sub_explicit(&vfork->refcount, 1, memory_order_release) == 1) {
+            cond_destroy(&vfork->cond);
+            free(vfork);
+        }
     }
 
     return pid;
@@ -639,4 +671,11 @@ void vfork_notify(struct task *task) {
     vfork->done = true;
     notify(&vfork->cond);
     unlock(&vfork->lock);
+
+    // Release child's refcount. If parent already cleared task->vfork and
+    // released its ref, this is the last ref — free the struct.
+    if (atomic_fetch_sub_explicit(&vfork->refcount, 1, memory_order_release) == 1) {
+        cond_destroy(&vfork->cond);
+        free(vfork);
+    }
 }

--- a/kernel/signal.c
+++ b/kernel/signal.c
@@ -455,12 +455,7 @@ static bool signal_is_synchronous_trap(int sig) {
     }
 }
 
-#define SIGNAL_IGNORE 0
-#define SIGNAL_KILL 1
-#define SIGNAL_CALL_HANDLER 2
-#define SIGNAL_STOP 3
-
-static int signal_action(struct sighand *sighand, int sig) {
+int signal_action(struct sighand *sighand, int sig) {
     if (signal_is_blockable(sig)) {
         struct sigaction_ *action = &sighand->action[sig];
         if(sig > 63)

--- a/kernel/signal.h
+++ b/kernel/signal.h
@@ -13,6 +13,14 @@ typedef qword_t sigset_t_;
 #define SIG_DFL_ 0
 #define SIG_IGN_ 1
 
+#define SIGNAL_IGNORE 0
+#define SIGNAL_KILL 1
+#define SIGNAL_CALL_HANDLER 2
+#define SIGNAL_STOP 3
+
+struct sighand;
+int signal_action(struct sighand *sighand, int sig);
+
 #define SA_SIGINFO_ 4
 #define SA_ONSTACK_ 0x08000000
 #define SA_RESTART_ 0x10000000

--- a/kernel/task.h
+++ b/kernel/task.h
@@ -188,8 +188,10 @@ struct task {
     // re-poke, same recovery contract as the io_block skip.
     _Atomic bool quiesce_parked;
 
-    // this structure is allocated on the stack of the parent's clone() call
+    // Heap-allocated, shared between parent and child via refcount.
+    // Parent holds one ref, vfork_notify holds one; last to release frees.
     struct vfork_info {
+        atomic_int refcount;
         bool done;
         cond_t cond;
         lock_t lock;


### PR DESCRIPTION
## What

vfork parent wait loop broke on ANY pending signal and use-after-free of stack-local vfork_info.

## Why

Two bugs found by emkey1:

1. **Signal handling too aggressive**: The original fix broke the vfork wait loop on ANY pending signal (including non-fatal ones like SIGALRM). Non-fatal signals corrupt the shared stack - parent and child share the same memory during vfork, so returning early lets the parent resume before the child calls execve or exit.

2. **Use-after-free**: `struct vfork_info` was stack-local to `sys_clone_common()`. If the parent broke out early (fatal signal), the child would later call `vfork_notify()` on a dangling pointer.

## Fix

- **Heap-allocate** `vfork_info` with `_Atomic int refcount` (2 = parent + child)
- **Fatal-only gate**: iterate pending unblocked signals, only break if `signal_action() == SIGNAL_KILL`
- **Kill child**: send `SIGKILL` to the child if parent breaks out early
- **Refcounted free**: both parent and child drop one ref; last one frees the struct
- Move `SIGNAL_*` constants and `signal_action()` declaration to `signal.h` for cross-file use

Reported-by: emkey1
