### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/linux/fakefs.c
+++ b/linux/fakefs.c
@@ -407,12 +407,13 @@ static int fakefs_iterate(struct file *file, struct dir_context *ctx) {
         if (res <= 0)
             break;
         // Get the inode number by constructing the file path and looking it up in the database
-        if (strcmp(ent.name, ".") == 0) {
+        size_t namelen_no_null = strlen(ent.name);
+        if (namelen_no_null == 1 && ent.name[0] == '.') {
             ent.ino = file->f_inode->i_ino;
-        } else if (strcmp(ent.name, "..") == 0) {
+        } else if (namelen_no_null == 2 && ent.name[0] == '.' && ent.name[1] == '.') {
             ent.ino = d_inode(file->f_path.dentry->d_parent)->i_ino;
         } else {
-            const size_t namelen = strlen(ent.name) + 1;
+            const size_t namelen = namelen_no_null + 1;
             if (dir_path_len + 1 + namelen > PATH_MAX)
                 continue; // a
 
@@ -423,7 +424,7 @@ static int fakefs_iterate(struct file *file, struct dir_context *ctx) {
             ent.ino = path_get_inode(&info->db, dir_path);
             sqlite3_mutex_leave(info->db.lock);
         }
-        if (!dir_emit(ctx, ent.name, strlen(ent.name), ent.ino, ent.type))
+        if (!dir_emit(ctx, ent.name, namelen_no_null, ent.ino, ent.type))
             break;
         ctx->pos = host_telldir(dir) + 1;
     }


### PR DESCRIPTION
💡 **What:** Optimized `fakefs_iterate` in `linux/fakefs.c` by calculating `strlen(ent.name)` exactly once per iteration and replacing `strcmp` calls with direct character index comparisons.
🎯 **Why:** Directory traversal is a hot path. The previous implementation repeatedly traversed `ent.name`: implicitly up to twice via `strcmp(".", ent.name)` and `strcmp("..", ent.name)`, and explicitly up to twice via `strlen(ent.name)`.
📊 **Impact:** Reduces redundant string traversals in directory iteration from up to 4x to 1x, providing a measurable micro-optimization for workloads involving heavy directory listing.
🔬 **Measurement:** Verify tests run successfully using `./tests/e2e/e2e.bash`.

---
*PR created automatically by Jules for task [15736543812575979224](https://jules.google.com/task/15736543812575979224) started by @emkey1*