### PR TITLE
🎨 Palette: Add accessibilityHint for terminal switcher long-press

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -424,7 +424,7 @@ static const NSInteger kMaximumTerminalFontSize = 72;
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
     }
     self.infoButton.accessibilityLabel = @"Settings";
-    self.infoButton.accessibilityHint = @"Opens the application settings.";
+    self.infoButton.accessibilityHint = @"Opens the application settings. Touch and hold to switch terminals.";
     self.pasteButton.accessibilityLabel = @"Paste";
     self.pasteButton.accessibilityHint = @"Pastes text from the clipboard.";
     self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
@@ -485,7 +485,7 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     button.translatesAutoresizingMaskIntoConstraints = NO;
     button.hidden = YES;
     button.accessibilityLabel = @"Settings";
-    button.accessibilityHint = @"Opens the application settings.";
+    button.accessibilityHint = @"Opens the application settings. Touch and hold to switch terminals.";
     button.backgroundColor = [UIColor colorWithWhite:0 alpha:0.35];
     button.layer.cornerRadius = 22;
     button.layer.masksToBounds = NO;


### PR DESCRIPTION
**💡 What:** Added an `accessibilityHint` to the info (settings) button and its floating variant to announce that a long-press will switch terminals.

**🎯 Why:** The buttons had a primary action (launching settings) and an explicit `accessibilityLabel` and `accessibilityHint` for that primary action. However, they also had a secondary action (launching the terminal switcher) triggered by a `UILongPressGestureRecognizer`. Because this gesture was not documented in the accessibility metadata, VoiceOver users had no way of knowing the functionality existed. This change makes the hidden interaction discoverable.

**📸 Before/After:**
*   **Before:** VoiceOver reads: "Settings. Button. Opens the application settings."
*   **After:** VoiceOver reads: "Settings. Button. Opens the application settings. Touch and hold to switch terminals."

**♿ Accessibility:** Improves discoverability of hidden gesture-based interactions for screen reader users by explicitly announcing secondary functionality.

---
*PR created automatically by Jules for task [1225012684054970615](https://jules.google.com/task/1225012684054970615) started by @emkey1*