### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/fs/aok.c
+++ b/fs/aok.c
@@ -579,7 +579,9 @@ static int aokfs_fstat(struct fd *fd, struct statbuf *stat) {
 }
 
 static int aokfs_getpath(struct fd *fd, char *buf) {
-    strcpy(buf, aokfs_node_path(aokfs_decode_node(fd->fs_data)));
+    const char *path = aokfs_node_path(aokfs_decode_node(fd->fs_data));
+    strncpy(buf, path, MAX_PATH - 1);
+    buf[MAX_PATH - 1] = '\0';
     return 0;
 }
 
@@ -798,7 +800,8 @@ static int aokfs_readdir(struct fd *fd, struct dir_entry *entry) {
 
     entry->inode = aokfs_node_inode(child);
     entry->type = dir_entry_type_for_mode(aokfs_node_mode(child));
-    strcpy(entry->name, aokfs_node_basename(child));
+    strncpy(entry->name, aokfs_node_basename(child), sizeof(entry->name) - 1);
+    entry->name[sizeof(entry->name) - 1] = '\0';
     return 1;
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded string copies (`strcpy`) writing to fixed-size char arrays (`char name[NAME_MAX + 1]` and `char buf[MAX_PATH]`) in `fs/aok.c`. If an upstream aokfs node returns a name or path larger than these structures, it will cause a buffer overflow, potentially corrupting kernel memory.
🎯 Impact: Memory corruption, kernel panic, or potential privilege escalation if an attacker can manipulate the underlying aokfs node names.
🔧 Fix: Replaced `strcpy` with `strncpy` and ensured explicit null-termination for `aokfs_getpath` and `aokfs_readdir`.
✅ Verification: Ran `meson setup build && ninja -C build` and `./tests/e2e/e2e.bash` to verify compilation and that existing tests still pass.

---
*PR created automatically by Jules for task [17404899965479670170](https://jules.google.com/task/17404899965479670170) started by @emkey1*