### PR TITLE
⚡ Bolt: Optimize string comparisons in fakefs_readdir

### DIFF
--- a/fs/fake.c
+++ b/fs/fake.c
@@ -675,13 +675,14 @@ retry:
     // this is annoying
     char entry_path[MAX_PATH + 1];
     realfs_getpath(fd, entry_path);
-    if (strcmp(entry->name, "..") == 0) {
+    // Cache strlen to avoid redundant calculations in bounds checking and loops
+    size_t name_len = strlen(entry->name);
+    if (name_len == 2 && entry->name[0] == '.' && entry->name[1] == '.') {
         if (strcmp(entry_path, "") != 0) {
             *strrchr(entry_path, '/') = '\0';
         }
-    } else if (strcmp(entry->name, ".") != 0) {
+    } else if (!(name_len == 1 && entry->name[0] == '.')) {
         size_t path_len = strlen(entry_path);
-        size_t name_len = strlen(entry->name);
         // god I don't know what to do if this would overflow
         if (path_len + 1 + name_len >= sizeof(entry_path))
             goto retry;


### PR DESCRIPTION
**💡 What:** Replaced `strcmp` calls for `.` and `..` with direct character/length comparisons in `fakefs_readdir`, and cached `strlen(entry->name)` to reuse it in bounds checking.
**🎯 Why:** `fakefs_readdir` is a tight loop used when traversing the filesystem. Using `strcmp` involves implicit string length traversals that can be optimized away.
**📊 Impact:** Small performance micro-optimization by eliminating redundant O(N) traversals per entry, scaling slightly better for large directories.
**🔬 Measurement:** N/A (micro-optimization, impact is small but structurally sound).

---
*PR created automatically by Jules for task [4202686638529115341](https://jules.google.com/task/4202686638529115341) started by @emkey1*