### PR TITLE
🎨 Palette: [UX improvement] Make terminal switcher accessibility hint dynamic

### DIFF
--- a/app/TerminalViewController.m
+++ b/app/TerminalViewController.m
@@ -438,7 +438,7 @@ static const NSInteger kMaximumTerminalFontSize = 72;
         [self.escapeKey setImage:[UIImage systemImageNamed:@"escape"] forState:UIControlStateNormal];
     }
     self.infoButton.accessibilityLabel = @"Settings";
-    self.infoButton.accessibilityHint = @"Opens the application settings. Touch and hold to switch terminals.";
+    self.infoButton.accessibilityHint = @"Opens the application settings.";
     self.pasteButton.accessibilityLabel = @"Paste";
     self.pasteButton.accessibilityHint = @"Pastes text from the clipboard.";
     self.hideKeyboardButton.accessibilityLabel = @"Hide Keyboard";
@@ -499,7 +499,7 @@ static const NSInteger kMaximumTerminalFontSize = 72;
     button.translatesAutoresizingMaskIntoConstraints = NO;
     button.hidden = YES;
     button.accessibilityLabel = @"Settings";
-    button.accessibilityHint = @"Opens the application settings. Touch and hold to switch terminals.";
+    button.accessibilityHint = @"Opens the application settings.";
     button.backgroundColor = [UIColor colorWithWhite:0 alpha:0.35];
     button.layer.cornerRadius = 22;
     button.layer.masksToBounds = NO;
@@ -784,6 +784,14 @@ static const NSInteger kMaximumTerminalFontSize = 72;
                                                       action:@selector(showTerminalSwitcher:)];
     recognizer.minimumPressDuration = 0.5;
     [view addGestureRecognizer:recognizer];
+    if ([view respondsToSelector:@selector(setAccessibilityHint:)]) {
+        NSString *currentHint = view.accessibilityHint;
+        if (currentHint.length > 0 && ![currentHint containsString:@"Touch and hold to switch terminals."]) {
+            view.accessibilityHint = [NSString stringWithFormat:@"%@ Touch and hold to switch terminals.", currentHint];
+        } else if (currentHint.length == 0) {
+            view.accessibilityHint = @"Touch and hold to switch terminals.";
+        }
+    }
 }
 
 - (void)_installTerminalStartupOverlay {


### PR DESCRIPTION
💡 **What**: Refactored the terminal switcher long-press accessibility hint in `TerminalViewController.m` to be applied dynamically when the gesture is added, rather than hardcoded on specific buttons.
🎯 **Why**: Previously, the accessibility hint "Touch and hold to switch terminals" was manually set on `infoButton` and `floatingSettingsButton`, but other buttons (like the standard `terminalSwitcherButton`) could also trigger the switcher. Tying the hint to the gesture installation method ensures the accessibility hint perfectly matches the actual capability of the view, preventing missing hints or incorrect descriptions if UI elements are updated.
📸 **Before/After**: N/A - Non-visual accessibility change.
♿ **Accessibility**: VoiceOver will now accurately and consistently announce the hidden secondary long-press action ("Touch and hold to switch terminals") for *all* buttons that actually have that gesture applied, rather than just the manually hardcoded ones.

---
*PR created automatically by Jules for task [10970981392965887440](https://jules.google.com/task/10970981392965887440) started by @emkey1*