### PR TITLE
⚡ Bolt: Optimize finding the last slash in a path

### DIFF
--- a/fs/path.c
+++ b/fs/path.c
@@ -219,9 +219,14 @@ int path_normalize(struct fd *at, const char *path, char *out, int flags) {
             return 0;
         }
         size_t last_slash = 0;
-        for (size_t i = 0; i < len; i++)
-            if (out[i] == '/')
-                last_slash = i;
+        // Bolt: Optimize finding the last slash by scanning backward instead of forward.
+        // Impact: Avoids unnecessary iterations on long paths, yielding O(1) performance in the best case.
+        for (size_t i = len; i > 0; i--) {
+            if (out[i - 1] == '/') {
+                last_slash = i - 1;
+                break;
+            }
+        }
         if (last_slash == 0) {
             // parent is the filesystem root, e.g. creating "/foo". The
             // mount-relative representation of the root used throughout this


### PR DESCRIPTION
💡 What: Modified `path_normalize` in `fs/path.c` to find the last slash by scanning backward (`for (size_t i = len; i > 0; i--)`) rather than scanning forward from the beginning of the string.
🎯 Why: The original code always scanned the entire string up to `len` to find the last slash, executing O(N) loop iterations every time. Since the goal is specifically to find the *last* slash, a backward scan can terminate as soon as the target is found.
📊 Impact: Reduces loop iterations to O(1) in the best case (when the slash is near the end), speeding up path normalization operations which are extremely hot paths during VFS resolutions.
🔬 Measurement: Verified with a synthetic C benchmark (`test_speed.c`) showing the backward loop is significantly faster than the forward loop, and `strrchr` was deemed unsafe because the `out` buffer may not be properly null-terminated at the expected boundary during dynamic modification.

---
*PR created automatically by Jules for task [11722042930638974504](https://jules.google.com/task/11722042930638974504) started by @emkey1*