### PR TITLE
🎨 Palette: [UX improvement] Improve bookmark button accessibility

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -12178,7 +12178,15 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
 
 - (void)updateBookmarkButtonState {
     NSString *url = [self currentBrowserWebView].URL.absoluteString;
-    [_bookmarkButton setTitle:ISHWorkspaceBrowserIsBookmarked(url) ? @"★" : @"☆" forState:UIControlStateNormal];
+    BOOL isBookmarked = ISHWorkspaceBrowserIsBookmarked(url);
+    [_bookmarkButton setTitle:isBookmarked ? @"★" : @"☆" forState:UIControlStateNormal];
+    if (isBookmarked) {
+        _bookmarkButton.accessibilityTraits |= UIAccessibilityTraitSelected;
+        _bookmarkButton.accessibilityValue = @"Bookmarked";
+    } else {
+        _bookmarkButton.accessibilityTraits &= ~UIAccessibilityTraitSelected;
+        _bookmarkButton.accessibilityValue = @"Not bookmarked";
+    }
 }
 
 - (void)handleBookmarkButtonLongPress:(UILongPressGestureRecognizer *)recognizer {


### PR DESCRIPTION
-   💡 What: Added `UIAccessibilityTraitSelected` and `accessibilityValue` to the bookmark button based on whether the current page is bookmarked.
-   🎯 Why: The bookmark button previously only updated its visual title ("★" vs "☆"), which is not sufficiently descriptive for VoiceOver users. Now, screen readers will correctly announce when the page is bookmarked.
-   📸 Before/After: N/A (Non-visual change).
-   ♿ Accessibility: VoiceOver now announces the "Selected" trait and "Bookmarked" / "Not bookmarked" value to clearly communicate the state of the button.

---
*PR created automatically by Jules for task [9810597061006050558](https://jules.google.com/task/9810597061006050558) started by @emkey1*