### PR TITLE
🎨 Palette: [UX improvement] Remove redundant accessibilityValue from bookmark button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -12169,10 +12169,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     [_bookmarkButton setTitle:isBookmarked ? @"★" : @"☆" forState:UIControlStateNormal];
     if (isBookmarked) {
         _bookmarkButton.accessibilityTraits |= UIAccessibilityTraitSelected;
-        _bookmarkButton.accessibilityValue = @"Bookmarked";
     } else {
         _bookmarkButton.accessibilityTraits &= ~UIAccessibilityTraitSelected;
-        _bookmarkButton.accessibilityValue = @"Not bookmarked";
     }
 }
 


### PR DESCRIPTION
### 💡 What
Removed the custom `accessibilityValue` assignments ("Bookmarked" / "Not bookmarked") from the bookmark button in `WorkspaceViewController.m`.

### 🎯 Why
The button already correctly toggles the `UIAccessibilityTraitSelected` trait. Appending a custom `accessibilityValue` on top of this trait causes VoiceOver to announce redundant information (e.g., "Selected, Bookmarked, Button"), which is unnecessarily chatty. Furthermore, hardcoded English strings defeat localization. Relying solely on the standard trait allows VoiceOver to announce the state natively and concisely.

### 📸 Before/After
**Before:** VoiceOver announces "Selected, Bookmarked, Button" (or similar depending on OS version) when the bookmark is active.
**After:** VoiceOver cleanly announces "Selected, Button" using native OS localization.

### ♿ Accessibility
This directly improves the screen reader experience by removing redundant, hardcoded speech output and relying on standard semantic HTML/iOS traits.

---
*PR created automatically by Jules for task [4234023801111593121](https://jules.google.com/task/4234023801111593121) started by @emkey1*