### PR TITLE
🎨 Palette: [UX improvement] Remove redundant accessibilityValue from bookmark button

### DIFF
--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -12169,10 +12169,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     [_bookmarkButton setTitle:isBookmarked ? @"★" : @"☆" forState:UIControlStateNormal];
     if (isBookmarked) {
         _bookmarkButton.accessibilityTraits |= UIAccessibilityTraitSelected;
-        _bookmarkButton.accessibilityValue = @"Bookmarked";
     } else {
         _bookmarkButton.accessibilityTraits &= ~UIAccessibilityTraitSelected;
-        _bookmarkButton.accessibilityValue = @"Not bookmarked";
     }
 }
 


### PR DESCRIPTION
**What:** 
Removed the custom `accessibilityValue` ("Bookmarked" / "Not bookmarked") from the workspace bookmark button.

**Why:** 
The button already uses `UIAccessibilityTraitSelected` to convey its active state. Setting a custom `accessibilityValue` simultaneously forces VoiceOver to announce both the trait and the value, creating a confusing and redundant experience for screen reader users.

**Before/After:**
- **Before:** VoiceOver announces "Selected, Bookmark, Bookmarked, Button" (or similar redundancy based on user settings).
- **After:** VoiceOver correctly relies entirely on the native trait, announcing "Selected, Bookmark, Button".

**Accessibility:**
Eliminates duplicate announcements, resulting in a cleaner and more standard UX.

---
*PR created automatically by Jules for task [15491289535264522315](https://jules.google.com/task/15491289535264522315) started by @emkey1*