### PR TITLE
⚡ Bolt: [performance improvement] Use stack buffer for small preadv/pwritev

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,7 @@
 ## 2026-03-28 - Optimize finding the last slash in a path
 **Learning:** In `fs/generic.c`, finding the last slash in a path by iterating over the string character by character (using `strlen` and a `for` loop) is an inefficient O(N) operation compared to optimized library functions like `strrchr`, which are often vectorized.
 **Action:** Replace manual character-by-character loops for finding the last character with `strrchr` and pointer arithmetic to significantly improve performance, especially for long path strings.
+
+## 2024-05-25 - sys_preadv and sys_pwritev performance
+**Learning:** System calls `sys_preadv` and `sys_pwritev` in `kernel/fs.c` flatten vectorized I/O requests into a single buffer. Before, they always used `malloc()` to allocate this buffer, regardless of the size. This incurs significant performance overhead for small readv/writev calls which are very common, mirroring the issue previously fixed in `sys_readv` and `sys_writev`.
+**Action:** Implemented a fast path using an explicitly aligned `256`-byte stack buffer for small `sys_preadv` and `sys_pwritev` requests, similar to existing optimizations in `sys_readv`, `sys_writev`, `sys_read`, `sys_write`, `sys_pread` and `sys_pwrite`. Only requests larger than 256 bytes will now fall back to heap allocation.

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -1126,10 +1126,14 @@ static dword_t sys_preadv_common(fd_t fd_no, guest_addr_t iovec_addr, dword_t io
     size_t io_size = iovec_size(iovec, iovec_count);
     if (io_size > MAX_RW_COUNT)
         io_size = MAX_RW_COUNT;
-    char *buf = malloc(io_size + 1);
-    if (buf == NULL) {
-        free(iovec);
-        return _ENOMEM;
+    char stack_buf[256] __attribute__((aligned(16)));
+    char *buf = stack_buf;
+    if (io_size + 1 > sizeof(stack_buf)) {
+        buf = malloc(io_size + 1);
+        if (buf == NULL) {
+            free(iovec);
+            return _ENOMEM;
+        }
     }
     struct fd *fd = f_get(fd_no);
     ssize_t res;
@@ -1171,7 +1175,8 @@ static dword_t sys_preadv_common(fd_t fd_no, guest_addr_t iovec_addr, dword_t io
         }
     }
 out:
-    free(buf);
+    if (buf != stack_buf)
+        free(buf);
     free(iovec);
     return res;
 }
@@ -1190,10 +1195,14 @@ static dword_t sys_pwritev_common(fd_t fd_no, guest_addr_t iovec_addr, dword_t i
     size_t io_size = iovec_size(iovec, iovec_count);
     if (io_size > MAX_RW_COUNT)
         io_size = MAX_RW_COUNT;
-    char *buf = malloc(io_size + 1);
-    if (buf == NULL) {
-        free(iovec);
-        return _ENOMEM;
+    char stack_buf[256] __attribute__((aligned(16)));
+    char *buf = stack_buf;
+    if (io_size + 1 > sizeof(stack_buf)) {
+        buf = malloc(io_size + 1);
+        if (buf == NULL) {
+            free(iovec);
+            return _ENOMEM;
+        }
     }
     ssize_t res = 0;
     size_t offset = 0;
@@ -1233,7 +1242,8 @@ static dword_t sys_pwritev_common(fd_t fd_no, guest_addr_t iovec_addr, dword_t i
     task_may_block_end();
     io_account_write(fd, res);
 out:
-    free(buf);
+    if (buf != stack_buf)
+        free(buf);
     free(iovec);
     return res;
 }


### PR DESCRIPTION
💡 **What**:
Optimized `sys_preadv_common` and `sys_pwritev_common` in `kernel/fs.c` to use a 256-byte stack-allocated buffer (aligned to 16 bytes) for small scatter-gather I/O requests instead of blindly calling `malloc()` for every request. It correctly falls back to heap allocation when the required buffer exceeds the stack buffer size.

🎯 **Why**:
Small, frequent I/O requests are extremely common. The overhead of repeatedly calling `malloc()` and `free()` for small buffers in the critical path of `preadv` and `pwritev` system calls adds measurable latency. This change mirrors an existing, proven optimization previously applied to `sys_readv` and `sys_writev`, ensuring consistent performance across the vectorized I/O fast paths.

📊 **Impact**:
Reduces heap allocation overhead to zero for all `preadv` and `pwritev` calls requiring 255 bytes or less, improving system call throughput for small payload scatter/gather operations.

🔬 **Measurement**:
Run typical workload traces or `strace` tests that invoke frequent small `preadv`/`pwritev` system calls, and observe the reduction in memory allocation latency in a profiler. The existing test suite was run (`ninja -C build` and `./tests/e2e/e2e.bash`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [7947809029910931059](https://jules.google.com/task/7947809029910931059) started by @emkey1*