### PR TITLE
fs/sock: an RTM_GETLINK dump must ignore the request's family (fixes `ip -4 addr` / `ip -6 addr`)

### DIFF
--- a/fs/sock.c
+++ b/fs/sock.c
@@ -721,12 +721,26 @@ static int netlink_append_route_links(struct fd *sock, const struct nlmsghdr_ *r
     if (getifaddrs(&addrs) != 0)
         return _EIO;
 
+    // Linux does NOT filter a link dump by the request's ifi_family: the
+    // RTM_GETLINK dump handler is registered under PF_UNSPEC and every other
+    // family falls back to it, so AF_INET/AF_INET6/AF_PACKET/AF_NETLINK all
+    // return the complete link list. Only PF_BRIDGE has its own handler
+    // (rtnl_bridge_getlink), which emits bridge ports only -- none here.
+    //
+    // We used to drop every link for any family other than AF_UNSPEC/AF_PACKET,
+    // which made `ip -4 addr` and `ip -6 addr` print NOTHING: iproute2 asks for
+    // the links first (with ifi_family set to the -4/-6 family), builds its
+    // ifindex->name map from the reply, then asks for the addresses. The
+    // address dump was already correct and filtered properly, but with an empty
+    // link map iproute2 has no name to attach an address to and silently drops
+    // every one of them. Plain `ip addr` sends AF_UNSPEC and was unaffected,
+    // which is why this hid: the family-qualified forms are the only casualties.
     uint8_t family = netlink_route_request_family(payload, payload_len);
     int err = 0;
     for (const struct ifaddrs *cursor = addrs; cursor != NULL; cursor = cursor->ifa_next) {
         if (cursor->ifa_name == NULL)
             continue;
-        if (family != AF_UNSPEC && family != AF_PACKET_ && family != 0)
+        if (family == AF_BRIDGE_)
             continue;
         bool seen = false;
         for (const struct ifaddrs *prev = addrs; prev != cursor; prev = prev->ifa_next) {

--- a/fs/sock.h
+++ b/fs/sock.h
@@ -184,11 +184,13 @@ struct scm {
 
 #define PF_LOCAL_ 1
 #define PF_INET_ 2
+#define PF_BRIDGE_ 7
 #define PF_NETLINK_ 16
 #define PF_PACKET_ 17
 #define PF_INET6_ 10
 #define AF_LOCAL_ PF_LOCAL_
 #define AF_INET_ PF_INET_
+#define AF_BRIDGE_ PF_BRIDGE_
 #define AF_NETLINK_ PF_NETLINK_
 #define AF_PACKET_ PF_PACKET_
 #define AF_INET6_ PF_INET6_

--- a/tests/manual/netlink_route.c
+++ b/tests/manual/netlink_route.c
@@ -42,6 +42,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
+#include <sys/utsname.h>
 #include <netinet/in.h>
 
 #include "test_common.h"
@@ -414,9 +415,19 @@ static void test_link_dump_family_filter(void) {
         check(lab, n, base);
     }
 
-    /* AF_BRIDGE is the one family Linux answers differently: bridge ports only,
-     * and iSH-AOK has no bridge devices, so an empty list is the correct reply. */
-    check("famlink.bridge_empty", count_dump_family(RTM_GETLINK_, RTM_NEWLINK_, 7), 0);
+    /* AF_BRIDGE is the one family Linux answers differently: rtnl_bridge_getlink
+     * emits bridge ports only. iSH-AOK has no bridge devices, so the reply must
+     * be empty. On a real kernel that is only true when the host has no bridge
+     * (a docker host has docker0), so assert the exact count under iSH and
+     * merely a subset elsewhere -- otherwise this suite fails on any Linux box
+     * that happens to run containers. */
+    int bridge = count_dump_family(RTM_GETLINK_, RTM_NEWLINK_, 7);
+    struct utsname uts;
+    int under_ish = uname(&uts) == 0 && strstr(uts.release, "ish") != NULL;
+    if (under_ish)
+        check("famlink.bridge_empty", bridge, 0);
+    else
+        check("famlink.bridge_subset", bridge >= 0 && bridge <= base, 1);
 
     /* The address dump, unlike the link dump, IS filtered by family on Linux
      * (separate per-family handlers). Guard that the fix above did not turn the

--- a/tests/manual/netlink_route.c
+++ b/tests/manual/netlink_route.c
@@ -166,7 +166,8 @@ static const char *method_name(enum io_method m) {
 
 /* Send one RTM_GET* dump request via the chosen io method; returns the
  * write/send result (request length on success, <0 on error). */
-static ssize_t send_dump(int fd, enum io_method m, int type, uint32_t seq) {
+static ssize_t send_dump_family(int fd, enum io_method m, int type, uint32_t seq,
+                                uint8_t family) {
     char req[NL_LENGTH(sizeof(struct nl_genmsg))];
     memset(req, 0, sizeof req);
     struct nl_hdr *nlh = (struct nl_hdr *) req;
@@ -175,7 +176,7 @@ static ssize_t send_dump(int fd, enum io_method m, int type, uint32_t seq) {
     nlh->nlmsg_flags = NLM_F_REQUEST_ | NLM_F_DUMP_;
     nlh->nlmsg_seq = seq;
     nlh->nlmsg_pid = 0;
-    ((struct nl_genmsg *) NL_DATA(nlh))->rtgen_family = 0; /* AF_UNSPEC: all */
+    ((struct nl_genmsg *) NL_DATA(nlh))->rtgen_family = family;
 
     if (m == IO_RW)
         return write(fd, req, sizeof req);
@@ -185,6 +186,10 @@ static ssize_t send_dump(int fd, enum io_method m, int type, uint32_t seq) {
     }
     struct nl_sockaddr dst = { .nl_family = AF_NETLINK };
     return sendto(fd, req, sizeof req, 0, (struct sockaddr *) &dst, sizeof dst);
+}
+
+static ssize_t send_dump(int fd, enum io_method m, int type, uint32_t seq) {
+    return send_dump_family(fd, m, type, seq, 0); /* AF_UNSPEC: all */
 }
 
 static ssize_t recv_batch(int fd, enum io_method m, char *buf, size_t cap) {
@@ -343,6 +348,87 @@ static void test_ifr_txqlen(void) {
     close(fd);
 }
 
+/* Count RTM_NEW* replies to one dump request made with an explicit family.
+ * Returns the count, or -1 if the reply stream carried an NLMSG_ERROR. */
+static int count_dump_family(int req_type, int expect_new, uint8_t family) {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0)
+        return -1;
+    if (send_dump_family(fd, IO_SEND, req_type, 0x5150 + family, family) <= 0) {
+        close(fd);
+        return -1;
+    }
+
+    char buf[64 * 1024];
+    int seen = 0, done = 0, err = 0;
+    arm_alarm(10);
+    while (!done && !alarm_fired) {
+        ssize_t n = recv_batch(fd, IO_SEND, buf, sizeof buf);
+        if (n <= 0)
+            break;
+        struct nl_hdr *nlh = (struct nl_hdr *) buf;
+        size_t len = (size_t) n;
+        for (; NL_OK(nlh, len); nlh = NL_NEXT(nlh, len)) {
+            if (nlh->nlmsg_type == NLMSG_DONE_) { done = 1; break; }
+            if (nlh->nlmsg_type == NLMSG_ERROR_) { err = 1; done = 1; break; }
+            if (nlh->nlmsg_type == expect_new)
+                seen++;
+        }
+    }
+    alarm(0);
+    close(fd);
+    return err ? -1 : seen;
+}
+
+/* An RTM_GETLINK dump must return the SAME link list no matter which family
+ * the request names. Linux registers the link dump under PF_UNSPEC and every
+ * other family falls through to it; only PF_BRIDGE has its own handler
+ * (rtnl_bridge_getlink), which emits bridge ports only. Verified against real
+ * Linux (iproute2 6.15.0, kernel 6.12): families 0/2/10/16/17 all return the
+ * full list, family 7 returns none.
+ *
+ * iSH-AOK dropped every link for any family except AF_UNSPEC/AF_PACKET, which
+ * is invisible to plain `ip addr` (it sends AF_UNSPEC) but makes `ip -4 addr`
+ * and `ip -6 addr` print NOTHING: iproute2 dumps links first to build its
+ * ifindex->name map, and an empty map means every address it then receives has
+ * no interface to attach to and is silently dropped. The address dump itself
+ * was always correct, so the addresses really were arriving and being thrown
+ * away, which is why the failure looked like "no addresses" rather than an
+ * error. */
+static void test_link_dump_family_filter(void) {
+    static const struct { uint8_t fam; const char *name; } families[] = {
+        { 2,  "inet" }, { 10, "inet6" }, { 16, "netlink" }, { 17, "packet" },
+    };
+
+    int base = count_dump_family(RTM_GETLINK_, RTM_NEWLINK_, 0 /* AF_UNSPEC */);
+    check("famlink.unspec_have_links", base >= 1, 1);
+    if (base < 1)
+        return;
+
+    for (size_t i = 0; i < sizeof families / sizeof *families; i++) {
+        char lab[64];
+        int n = count_dump_family(RTM_GETLINK_, RTM_NEWLINK_, families[i].fam);
+        test_log_if(n != base, "  famlink: AF_%s dump returned %d links, AF_UNSPEC returned %d\n",
+                    families[i].name, n, base);
+        snprintf(lab, sizeof lab, "famlink.%s_matches_unspec", families[i].name);
+        check(lab, n, base);
+    }
+
+    /* AF_BRIDGE is the one family Linux answers differently: bridge ports only,
+     * and iSH-AOK has no bridge devices, so an empty list is the correct reply. */
+    check("famlink.bridge_empty", count_dump_family(RTM_GETLINK_, RTM_NEWLINK_, 7), 0);
+
+    /* The address dump, unlike the link dump, IS filtered by family on Linux
+     * (separate per-family handlers). Guard that the fix above did not turn the
+     * address filter off too: an AF_INET address dump must not exceed the
+     * unfiltered one, and both must be non-empty (every host has 127.0.0.1). */
+    int addr_all = count_dump_family(RTM_GETADDR_, RTM_NEWADDR_, 0);
+    int addr_v4 = count_dump_family(RTM_GETADDR_, RTM_NEWADDR_, 2);
+    check("famaddr.unspec_have_addrs", addr_all >= 1, 1);
+    check("famaddr.inet_have_addrs", addr_v4 >= 1, 1);
+    check("famaddr.inet_subset_of_all", addr_v4 <= addr_all, 1);
+}
+
 int main(int argc, char **argv) {
     test_init(argc, argv);
     signal(SIGPIPE, SIG_IGN);
@@ -354,6 +440,9 @@ int main(int argc, char **argv) {
     run_dump(IO_VEC, RTM_GETLINK_, RTM_NEWLINK_);
     /* send/recv was already wired; assert parity as a guard. */
     run_dump(IO_SEND, RTM_GETLINK_, RTM_NEWLINK_);
+
+    /* A family-qualified link dump must match the unqualified one (`ip -4 addr`). */
+    test_link_dump_family_filter();
 
     /* The SIOCGIFTXQLEN ioctl `ip addr` issues per interface. */
     test_ifr_txqlen();


### PR DESCRIPTION
## Symptom

`ip -4 addr` and `ip -6 addr` print **nothing** on every guest. Plain `ip addr` works.

```
$ ip -4 -o addr        # before: no output at all
$ ip -o addr | head -1 # same guest, same moment
1: lo0    inet 127.0.0.1/8 scope host lo0
```

The addresses were arriving correctly the whole time. `iproute2` was throwing them away.

## Root cause

`iproute2` runs a family-qualified `ip addr` as **two** dumps: `RTM_GETLINK` first, with `ifi_family` set to the `-4`/`-6` family, to build its ifindex-to-name map, then `RTM_GETADDR` for the addresses.

`netlink_append_route_links()` skipped every link unless the requested family was `AF_UNSPEC` or `AF_PACKET`, so the link dump came back as a bare `NLMSG_DONE`. With an empty link map `iproute2` has no interface to attach an address to and silently drops all of them. That is why this reads as "no addresses" rather than an error, and why plain `ip addr` escaped: it sends `AF_UNSPEC`.

Confirmed in an `strace` of `ip -4 addr` on device: the `RTM_GETLINK` reply is 20 bytes (`NLMSG_DONE` only), while the following `RTM_GETADDR` reply correctly carries all five IPv4 addresses.

## What Linux actually does

Linux does not filter a link dump by family at all. `rtnl_dump_ifinfo` is registered under `PF_UNSPEC` and every other family falls through to it; `rtnl_valid_dump_ifinfo_req` validates `ifi_pad`/`type`/`flags`/`change`/`index` but deliberately **not** `ifi_family`. Only `PF_BRIDGE` has its own handler, `rtnl_bridge_getlink`, which emits bridge ports only.

One probe, both platforms, same `iproute2` 6.15.0:

| `RTM_GETLINK` family | 0 (UNSPEC) | 2 (INET) | 10 (INET6) | 7 (BRIDGE) | 16 (NETLINK) | 17 (PACKET) |
|---|---|---|---|---|---|---|
| Linux 6.12 x86_64 | 4 | 4 | 4 | 0 | 4 | 4 |
| iSH-AOK 547 aarch64 | 28 | **0** | **0** | 0 | **0** | 28 |

## Fix

Ignore the requested family for link dumps, except `AF_BRIDGE`, which stays empty (iSH-AOK has no bridge devices, so that matches Linux).

The **address** dump was already correct and stays family-filtered, matching Linux's separate per-family handlers. The test guards that it did not become unfiltered as a side effect.

## Test

`tests/manual/netlink_route.c` gains `test_link_dump_family_filter`:

- a family-qualified link dump must match the `AF_UNSPEC` one for `AF_INET`/`AF_INET6`/`AF_NETLINK`/`AF_PACKET`
- `AF_BRIDGE` must stay empty
- the address dump must still filter by family

## A/B

| | result |
|---|---|
| iSH-AOK 547 unfixed, aarch64 guest (M4 iPad Pro) | **FAIL**, 3 checks |
| Same device, this branch installed | **PASS** |
| Real Linux (Debian 13, kernel 6.12, x86_64) | **PASS** |

Both device runs were done on the physical M4 iPad Pro, baseline captured before installing the fixed build, build stamps confirmed distinct (`2026-08-12 20:17Z` vs `2026-08-13 04:36Z`) rather than trusting the version number.

Surrounding suite re-run on the fixed device build, all green: `sock_conformance`, `accept_rcvtimeo`, `accept_kill`, `socket_kill`, `epoll_dup_add`, `scm_rights_pidfd`.

## Provenance

Found while investigating a downstream report from [R0GUEEE/systui](https://github.com/R0GUEEE/systui), an iSH-AOK-targeting sysadmin TUI that forces `Acquire::ForceIPv4` into every rootfs it builds, citing apt hangs and empty package lists.

**That apt claim did not reproduce** and is not what this fixes: against a dual-stack mirror on the M4, `apt-get update` took 13.8s with IPv6 allowed vs 13.4s forced to IPv4, no hang, no empty lists. The AAAA-without-a-route mechanism was also checked and is standard glibc behavior, not a deviation: `check_pf.c` sets `seen_ipv6` for any non-loopback IPv6 including link-local, so `AI_ADDRCONFIG` returns AAAA on a link-local-only host on real Linux too. Guest `connect()` to an unreachable IPv6 correctly fails fast with `EHOSTUNREACH`.

This bug turned up in the same subsystem while checking that report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)