### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -48,3 +48,7 @@
 **Vulnerability:** Widespread use of unbounded `sprintf` and `vsprintf` calls (e.g. `fs/pty.c`, `fs/proc/pid.c`, `fs/proc/root.c`, `fs/sock.c`, `emu/regid.h`, `emu/float80-test.c`, `tools/ptutil.c`, `tools/vdso-transplant.c`) writing to fixed-size buffers, posing significant buffer overflow risks.
 **Learning:** Hardcoded stack buffer sizes with string formatting lacking bounds checking create systemic vulnerabilities across various domains of the codebase (kernel, emulation, tooling, etc.).
 **Prevention:** Strictly utilize bounds-checked functions (`snprintf`, `vsnprintf`) combined with explicit buffer length parameters (e.g. `sizeof(buf)`) to inherently prevent buffer overflow conditions when constructing paths or log messages.
+## 2026-08-21 - Buffer Overflow in kernel/native.c
+**Vulnerability:** The `native_env_set` function used `sprintf` to write into a dynamically allocated buffer. Although the buffer size was calculated beforehand, `sprintf` is inherently unsafe and can lead to a heap buffer overflow if integer overflow occurs during size calculation or if race conditions exist.
+**Learning:** Even when buffer sizes are explicitly calculated, `sprintf` should not be used as it does not enforce limits at the point of writing, increasing the risk of memory corruption.
+**Prevention:** Always use bounds-checking functions like `snprintf` combined with the explicitly calculated size variable to guarantee the write does not exceed the allocated bounds, even if calculations fail.

--- a/kernel/native.c
+++ b/kernel/native.c
@@ -538,10 +538,11 @@ int native_env_set(const char *name, const char *value, bool overwrite) {
             strchr(name, '=') != NULL)
         return _EINVAL;
 
-    char *entry = malloc(strlen(name) + strlen(value) + 2);
+    size_t entry_size = strlen(name) + strlen(value) + 2;
+    char *entry = malloc(entry_size);
     if (entry == NULL)
         return _ENOMEM;
-    sprintf(entry, "%s=%s", name, value);
+    snprintf(entry, entry_size, "%s=%s", name, value);
 
     ssize_t at = native_env_find(name);
     if (at >= 0) {


### PR DESCRIPTION
Replaced an unsafe `sprintf` call with `snprintf` in `native_env_set` to prevent potential heap buffer overflows.

Severity: MEDIUM
Vulnerability: `sprintf` used to write into a dynamically allocated buffer based on calculated size.
Impact: Potential heap buffer overflow if the size calculation experiences integer overflow or race conditions.
Fix: Switched to `snprintf` and explicitly passed the calculated allocation size as the limit.
Verification: Verified with `git diff`.

---
*PR created automatically by Jules for task [13306974611520964211](https://jules.google.com/task/13306974611520964211) started by @emkey1*