### PR TITLE
🎨 Palette: [UX improvement] Apply dynamic accessibilityLabel to Image Viewer zoom button

### DIFF
--- a/app/WorkspaceImageViewer.m
+++ b/app/WorkspaceImageViewer.m
@@ -496,6 +496,7 @@ static NSSet<NSString *> *ISHImageViewerSupportedExtensions(void) {
 
 - (void)updateZoomToggleTitle {
     [_zoomToggleButton setTitle:(_showingActualSize ? @"Fit" : @"100%") forState:UIControlStateNormal];
+    _zoomToggleButton.accessibilityLabel = _showingActualSize ? @"Fit to screen" : @"View actual size";
 }
 
 - (void)applyZoomMode {


### PR DESCRIPTION
What: Added a dynamic `accessibilityLabel` to the zoom toggle button (`_zoomToggleButton`) in `WorkspaceImageViewer.m` that updates in sync with its visual title ("Fit to screen" or "View actual size").
Why: The button dynamically changes its visual title between "Fit" and "100%" based on state. Without an explicit accessibility label, screen readers only read the terse title, which lacks sufficient context.
Before/After: Visuals remain unchanged, but VoiceOver now accurately describes the toggle's function.
Accessibility: The `accessibilityLabel` correctly reflects the actionable state, providing clear guidance for screen reader users.

---
*PR created automatically by Jules for task [4103904849277244247](https://jules.google.com/task/4103904849277244247) started by @emkey1*