### PR TITLE
⚡ Bolt: Replace strcmp with explicit character comparisons in fake-migrate

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,7 @@
 ## 2024-05-25 - sys_preadv and sys_pwritev performance
 **Learning:** System calls `sys_preadv` and `sys_pwritev` in `kernel/fs.c` flatten vectorized I/O requests into a single buffer. Before, they always used `malloc()` to allocate this buffer, regardless of the size. This incurs significant performance overhead for small readv/writev calls which are very common, mirroring the issue previously fixed in `sys_readv` and `sys_writev`.
 **Action:** Implemented a fast path using an explicitly aligned `256`-byte stack buffer for small `sys_preadv` and `sys_pwritev` requests, similar to existing optimizations in `sys_readv`, `sys_writev`, `sys_read`, `sys_write`, `sys_pread` and `sys_pwrite`. Only requests larger than 256 bytes will now fall back to heap allocation.
+
+## 2026-03-29 - Avoid strcmp overhead for simple literals
+**Learning:** In performance-critical directory traversal paths (e.g., in `fs/fake-migrate.c`), using `strcmp` against short literals like `.` and `..` involves function call overhead and multiple character comparisons. Modern C compilers can optimize short explicit character comparisons more efficiently.
+**Action:** Replace `strcmp` calls against `.` and `..` with explicit character array checks (e.g., `name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'))`) wrapped in an `is_dot_or_dotdot` inline helper to avoid function overhead while preserving readability.

--- a/fs/fake-migrate.c
+++ b/fs/fake-migrate.c
@@ -8,6 +8,11 @@
 #include <strings.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdbool.h>
+
+static inline bool is_dot_or_dotdot(const char *name) {
+    return name[0] == '.' && (name[1] == '\0' || (name[1] == '.' && name[2] == '\0'));
+}
 
 #include "kernel/fs.h"
 #include "debug.h"
@@ -492,7 +497,7 @@ static void scan_host_dir(int root_fd, const char *host_dir, const char *name,
     }
     struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
-        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+        if (is_dot_or_dotdot(ent->d_name))
             continue;
         char guest[NAME_MAX * 3 + 2];
         if (strlen(ent->d_name) >= sizeof(guest) || strlen(ent->d_name) >= out_size)
@@ -1196,7 +1201,7 @@ static bool migrate_names_load(int root_fd, const char *host_dir, struct migrate
     bool ok = true;
     struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
-        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+        if (is_dot_or_dotdot(ent->d_name))
             continue;
         if (!migrate_names_add(list, ent->d_name, &cap)) {
             ok = false;
@@ -1476,7 +1481,7 @@ static void migrate_repair_name_aliases(struct fakefs_db *fs, int root_fd) {
         struct migrate_names alias = {0};
         size_t alias_cap = 0;
         for (size_t i = 0; i < cache.count; i++) {
-            if (strcmp(cache.names[i], ".") == 0 || strcmp(cache.names[i], "..") == 0)
+            if (is_dot_or_dotdot(cache.names[i]))
                 continue;
             if (host_name_is_canonical(cache.names[i]))
                 continue;


### PR DESCRIPTION
* 💡 **What**: Replaced `strcmp` against `.` and `..` with an inline `is_dot_or_dotdot` helper that uses explicit byte comparisons.
* 🎯 **Why**: In hot VFS loops (like `fs/fake-migrate.c`), calling `strcmp` repeatedly incurs unnecessary function overhead. Modern compilers can turn explicit short character comparisons into fast inline integer comparisons.
* 📊 **Impact**: Expected to reduce CPU cycles in hot loops iterating over directories, avoiding function overhead. A synthetic test showed significant performance improvement.
* 🔬 **Measurement**: Verify via PR tests. Performance can be tested with a microbenchmark measuring iterations over `.` and `..`.

---
*PR created automatically by Jules for task [11930472994567949222](https://jules.google.com/task/11930472994567949222) started by @emkey1*