### PR TITLE
🎨 Palette: Dynamic Accessibility Labels for Zoom Toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-06-05 - Accessibility Labels for Factory-Generated Buttons
 **Learning:** When using a factory method to generate icon-only buttons with fallback text strings (like "M", "|<", ">|"), setting `accessibilityLabel` equal to the abbreviated fallback text does not provide enough context for VoiceOver users.
 **Action:** In button generation methods, expand abbreviated text placeholders into clear, descriptive `accessibilityLabel` values (e.g., mapping "M" to "Menu", ">|" to "Next Track") so VoiceOver users understand the button's purpose without relying on visual context.
+
+## 2024-06-06 - Dynamic Accessibility Labels for Toggle Buttons
+**Learning:** In iOS UI development, when a button toggles its title and purpose (e.g., between "Fit" and "100%"), its `accessibilityLabel` must also be dynamically updated to reflect the new action.
+**Action:** Always update the `accessibilityLabel` dynamically when a button's primary title or state changes.

--- a/app/WorkspaceImageViewer.m
+++ b/app/WorkspaceImageViewer.m
@@ -496,6 +496,7 @@ static NSSet<NSString *> *ISHImageViewerSupportedExtensions(void) {
 
 - (void)updateZoomToggleTitle {
     [_zoomToggleButton setTitle:(_showingActualSize ? @"Fit" : @"100%") forState:UIControlStateNormal];
+    _zoomToggleButton.accessibilityLabel = _showingActualSize ? @"Fit image to screen" : @"Show image at actual size";
 }
 
 - (void)applyZoomMode {


### PR DESCRIPTION
* 💡 What: The `accessibilityLabel` for the zoom toggle button now updates dynamically to reflect the button's action based on its state.
* 🎯 Why: Previously, the zoom toggle button changed its visual title between "Fit" and "100%", but its `accessibilityLabel` was static or undefined. This update ensures that VoiceOver users hear an accurate description of the button's action ("Fit image to screen" or "Show image at actual size") whenever its state changes.
* 📸 Before/After: Visuals remain exactly the same.
* ♿ Accessibility: Significant improvement for screen reader users by providing dynamic context to a state-changing button.

---
*PR created automatically by Jules for task [10490331447897154298](https://jules.google.com/task/10490331447897154298) started by @emkey1*