### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/kernel/native.c
+++ b/kernel/native.c
@@ -571,10 +571,12 @@ int native_env_set(const char *name, const char *value, bool overwrite) {
             strchr(name, '=') != NULL)
         return _EINVAL;
 
-    char *entry = malloc(strlen(name) + strlen(value) + 2);
+    size_t name_len = strlen(name);
+    size_t value_len = strlen(value);
+    char *entry = malloc(name_len + value_len + 2);
     if (entry == NULL)
         return _ENOMEM;
-    sprintf(entry, "%s=%s", name, value);
+    snprintf(entry, name_len + value_len + 2, "%s=%s", name, value);
 
     ssize_t at = native_env_find(name);
     if (at >= 0) {


### PR DESCRIPTION
The patch successfully implements a classic security enhancement by replacing `sprintf` with the bounds-checked `snprintf` in `kernel/native.c`. This addresses a potential heap-based buffer overflow vulnerability. The patch ensures that writing will safely truncate instead of corrupting memory if an integer overflow occurs during the allocation sizing. This is a standard security context enhancement aligned with defensive programming practices.

---
*PR created automatically by Jules for task [11475807205939179567](https://jules.google.com/task/11475807205939179567) started by @emkey1*