### PR TITLE
🎨 Palette: Add accessibility hint to file manager breadcrumb navigation

### DIFF
--- a/app/WorkspaceFileManager.m
+++ b/app/WorkspaceFileManager.m
@@ -367,6 +367,7 @@ static NSString *ISHHomeDirectoryForUID(NSData *passwdData, uid_t targetUID) {
         [button setTitle:titles[i] forState:UIControlStateNormal];
         [button setTitleColor:(isLast ? theme[@"primary"] : theme[@"accent"]) forState:UIControlStateNormal];
         button.enabled = !isLast;  // the current location isn't a link anywhere
+        button.accessibilityHint = isLast ? nil : @"Go to this folder";
         NSString *targetPath = prefixes[i];
         __weak typeof(self) weakSelf = self;
         [button addAction:[UIAction actionWithHandler:^(UIAction *action) {


### PR DESCRIPTION
💡 **What:** Added an `accessibilityHint` to the active breadcrumb buttons in `WorkspaceFileManager`.
🎯 **Why:** To match the pattern used in `ShellFileBrowser` and provide screen reader users with a clear explanation of what happens when they interact with a breadcrumb segment (e.g., announcing "Go to this folder").
📸 **Before/After:** N/A (This is a non-visual change that only impacts VoiceOver output).
♿ **Accessibility:** Significantly improves context for VoiceOver users when navigating deep directory structures by explicitly announcing the action triggered by the button.

---
*PR created automatically by Jules for task [6573583035667273114](https://jules.google.com/task/6573583035667273114) started by @emkey1*