### PR TITLE
🎨 Palette: [UX improvement] Add accessibilityHint to breadcrumb buttons

### DIFF
--- a/app/WorkspaceFileManager.m
+++ b/app/WorkspaceFileManager.m
@@ -367,6 +367,7 @@ static NSString *ISHHomeDirectoryForUID(NSData *passwdData, uid_t targetUID) {
         [button setTitle:titles[i] forState:UIControlStateNormal];
         [button setTitleColor:(isLast ? theme[@"primary"] : theme[@"accent"]) forState:UIControlStateNormal];
         button.enabled = !isLast;  // the current location isn't a link anywhere
+        if (!isLast) button.accessibilityHint = @"Go to this folder";
         NSString *targetPath = prefixes[i];
         __weak typeof(self) weakSelf = self;
         [button addAction:[UIAction actionWithHandler:^(UIAction *action) {


### PR DESCRIPTION
* 💡 What: Added an explicit `accessibilityHint` to the active (non-terminal) breadcrumb navigation buttons in `WorkspaceFileManager`.
* 🎯 Why: Breadcrumb buttons represent directory navigation, but their labels only contain the folder name. Adding a hint clarifies their action to VoiceOver users.
* 📸 Before/After: Visuals remain unchanged.
* ♿ Accessibility: VoiceOver now announces "Go to this folder" after the folder name for interactive breadcrumb components.

---
*PR created automatically by Jules for task [9847022170234151549](https://jules.google.com/task/9847022170234151549) started by @emkey1*