### PR TITLE
🎨 Palette: Add accessibility hint to file manager breadcrumb

### DIFF
--- a/app/WorkspaceFileManager.m
+++ b/app/WorkspaceFileManager.m
@@ -367,6 +367,7 @@ static NSString *ISHHomeDirectoryForUID(NSData *passwdData, uid_t targetUID) {
         [button setTitle:titles[i] forState:UIControlStateNormal];
         [button setTitleColor:(isLast ? theme[@"primary"] : theme[@"accent"]) forState:UIControlStateNormal];
         button.enabled = !isLast;  // the current location isn't a link anywhere
+        button.accessibilityHint = isLast ? nil : @"Go to this folder";
         NSString *targetPath = prefixes[i];
         __weak typeof(self) weakSelf = self;
         [button addAction:[UIAction actionWithHandler:^(UIAction *action) {


### PR DESCRIPTION
💡 What: Added an accessibility hint to the breadcrumb navigation buttons in the file manager.
🎯 Why: VoiceOver users lack clear context on what action breadcrumb buttons perform without a hint.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Added "Go to this folder" hint for active breadcrumb buttons so VoiceOver users are aware of the button's action.

---
*PR created automatically by Jules for task [795189381907661352](https://jules.google.com/task/795189381907661352) started by @emkey1*