### PR TITLE
🎨 Palette: Add accessibility hint to modern menu pip

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-06-05 - Accessibility Labels for Factory-Generated Buttons
 **Learning:** When using a factory method to generate icon-only buttons with fallback text strings (like "M", "|<", ">|"), setting `accessibilityLabel` equal to the abbreviated fallback text does not provide enough context for VoiceOver users.
 **Action:** In button generation methods, expand abbreviated text placeholders into clear, descriptive `accessibilityLabel` values (e.g., mapping "M" to "Menu", ">|" to "Next Track") so VoiceOver users understand the button's purpose without relying on visual context.
+## 2026-09-01 - Added accessibilityHint to Modern Menu Pip
+**Learning:** VoiceOver screen reader users need additional context on what the "Workspace menu" button does. A label alone doesn't clarify its function.
+**Action:** Added an `accessibilityHint` explaining that the button opens the desktop menu for window management.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -3885,6 +3885,7 @@ static UIView *ISHWorkspaceFindFirstResponder(UIView *view) {
     pip.layer.shadowRadius = 6.0;
     pip.layer.shadowOffset = CGSizeMake(0.0, 2.0);
     pip.accessibilityLabel = @"Workspace menu";
+    pip.accessibilityHint = @"Opens the desktop menu for window management.";
     [pip addTarget:self action:@selector(menuPipTapped:) forControlEvents:UIControlEventTouchUpInside];
     pip.hidden = !ISHWorkspaceUsesModernStyle();
     return pip;


### PR DESCRIPTION
💡 What: Added an `accessibilityHint` to the modern menu pip button in the Workspace UI.
🎯 Why: Screen reader users need additional context on what the "Workspace menu" button does, as the label alone doesn't clarify its function (opening the desktop menu for window management).
📸 Before/After: N/A (non-visual change).
♿ Accessibility: Improves VoiceOver experience by providing a clear, descriptive action hint for the modern menu pip button.

---
*PR created automatically by Jules for task [8096009859420607264](https://jules.google.com/task/8096009859420607264) started by @emkey1*