### PR TITLE
🎨 Palette: [UX improvement] Add accessibility label to overflow menu in Shell File Browser

### DIFF
--- a/app/ShellFileBrowser.m
+++ b/app/ShellFileBrowser.m
@@ -399,9 +399,10 @@ NSString *ISHShellQuoteArgument(NSString *argument) {
                                        identifier:nil
                                           handler:^(UIAction *action) { [weakSelf reload]; }];
     UIMenu *menu = [UIMenu menuWithTitle:@"" children:@[newFolder, hidden, refresh]];
-    self.navigationItem.rightBarButtonItem =
-        [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"ellipsis.circle"]
-                                          menu:menu];
+    UIBarButtonItem *overflow = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"ellipsis.circle"]
+                                                                  menu:menu];
+    overflow.accessibilityLabel = @"More options";
+    self.navigationItem.rightBarButtonItem = overflow;
 }
 
 - (void)toggleShowsHiddenFiles {


### PR DESCRIPTION
💡 What: Added an `accessibilityLabel` to the overflow menu button (ellipsis icon) in ShellFileBrowser.m.
🎯 Why: Icon-only buttons need descriptive labels for screen reader users to understand their purpose.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: VoiceOver will now announce "More options" instead of just "Button" or nothing when focusing on the overflow menu.

---
*PR created automatically by Jules for task [2702192136155455689](https://jules.google.com/task/2702192136155455689) started by @emkey1*