### PR TITLE
🎨 Palette: [UX] Improve accessibility labels for workspace icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -36,3 +36,10 @@
 ## 2026-09-01 - Added accessibilityHint to Modern Menu Pip
 **Learning:** VoiceOver screen reader users need additional context on what the "Workspace menu" button does. A label alone doesn't clarify its function.
 **Action:** Added an `accessibilityHint` explaining that the button opens the desktop menu for window management.
+## 2024-09-13 - Decoupling Accessibility Labels from Visual Fallbacks
+**Learning:** Using short fallback strings (like "Save" or "Restore") directly as `accessibilityLabel`s for icon-only buttons provides insufficient context for screen reader users when multiple similar actions exist in the UI (e.g., "Save Layout" vs "Save Session").
+**Action:** When creating icon-only buttons with factory methods, pass an explicit `accessibilityLabel` parameter instead of blindly reusing the visual fallback string, ensuring VoiceOver receives the full contextual description.
+
+## 2024-09-13 - Decoupling Accessibility Labels from Visual Fallbacks
+**Learning:** Using short fallback strings (like "Save" or "Restore") directly as `accessibilityLabel`s for icon-only buttons provides insufficient context for screen reader users when multiple similar actions exist in the UI (e.g., "Save Layout" vs "Save Session").
+**Action:** When creating icon-only buttons with factory methods, pass an explicit `accessibilityLabel` parameter instead of blindly reusing the visual fallback string, ensuring VoiceOver receives the full contextual description.

--- a/app/WorkspaceViewController.m
+++ b/app/WorkspaceViewController.m
@@ -12034,7 +12034,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     return button;
 }
 
-- (UIButton *)workspacesIconButtonWithSymbol:(NSString *)symbol fallback:(NSString *)fallback action:(SEL)action {
+- (UIButton *)workspacesIconButtonWithSymbol:(NSString *)symbol fallback:(NSString *)fallback action:(SEL)action accessibilityLabel:(NSString *)label {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     if (@available(iOS 13.0, *)) {
@@ -12042,7 +12042,7 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
     } else {
         [button setTitle:fallback forState:UIControlStateNormal];
     }
-    button.accessibilityLabel = fallback;
+    button.accessibilityLabel = label;
     button.layer.cornerRadius = 12;
     [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
     [button.heightAnchor constraintEqualToConstant:ISHWorkspaceUsesPhoneLayout() ? 36.0 : 40.0].active = YES;
@@ -12500,7 +12500,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         [_contentStack addArrangedSubview:_closeHiddenButton];
         _sessionButton = [self workspacesIconButtonWithSymbol:@"arrow.down.doc"
                                                      fallback:@"Session"
-                                                       action:@selector(sessionActionsFromApplet:)];
+                                                       action:@selector(sessionActionsFromApplet:)
+                                           accessibilityLabel:@"Session Actions"];
         [_contentStack addArrangedSubview:_sessionButton];
     } else {
         // Modern folds the Layout Manager into this applet as two icons.
@@ -12508,8 +12509,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         layoutRow.axis = UILayoutConstraintAxisHorizontal;
         layoutRow.distribution = UIStackViewDistributionFillEqually;
         layoutRow.spacing = 6;
-        [layoutRow addArrangedSubview:[self workspacesIconButtonWithSymbol:@"square.and.arrow.down" fallback:@"Save" action:@selector(saveLayoutFromApplet:)]];
-        [layoutRow addArrangedSubview:[self workspacesIconButtonWithSymbol:@"arrow.clockwise" fallback:@"Restore" action:@selector(restoreLayoutFromApplet:)]];
+        [layoutRow addArrangedSubview:[self workspacesIconButtonWithSymbol:@"square.and.arrow.down" fallback:@"Save" action:@selector(saveLayoutFromApplet:) accessibilityLabel:@"Save Layout"]];
+        [layoutRow addArrangedSubview:[self workspacesIconButtonWithSymbol:@"arrow.clockwise" fallback:@"Restore" action:@selector(restoreLayoutFromApplet:) accessibilityLabel:@"Restore Layout"]];
         // In the row, as asked. The SAME symbol the shell-mode terminal uses for
         // its session control (arrow.down.doc, TerminalViewController's save
         // button), so the two modes say "session" the same way.
@@ -12521,7 +12522,8 @@ static NSURL *ISHWorkspaceBrowserURLFromInput(NSString *input) {
         // have to hunt for is worse than one you might misread once.
         _sessionButton = [self workspacesIconButtonWithSymbol:@"arrow.down.doc"
                                                      fallback:@"Session"
-                                                       action:@selector(sessionActionsFromApplet:)];
+                                                       action:@selector(sessionActionsFromApplet:)
+                                           accessibilityLabel:@"Session Actions"];
         [layoutRow addArrangedSubview:_sessionButton];
         [_contentStack addArrangedSubview:layoutRow];
     }


### PR DESCRIPTION
💡 What: Added explicit `accessibilityLabel` parameters to factory-generated workspace icon buttons, mapping abbreviations like "Save" to full contexts like "Save Layout".
🎯 Why: Using short fallback strings ("Save", "Restore") directly as `accessibilityLabel`s provides insufficient context for screen reader users when multiple similar actions exist.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improved screen reader announcements for Layout Manager and Session controls by explicitly decoupling the accessible label from the visual fallback text.

---
*PR created automatically by Jules for task [4156920971527938988](https://jules.google.com/task/4156920971527938988) started by @emkey1*